### PR TITLE
Implemented modulemap parser in Starlark

### DIFF
--- a/spm/internal/modulemap_parser/BUILD.bazel
+++ b/spm/internal/modulemap_parser/BUILD.bazel
@@ -8,6 +8,13 @@ bzl_library(
 )
 
 bzl_library(
+    name = "collection_results",
+    srcs = ["collection_results.bzl"],
+    visibility = ["//spm:__subpackages__"],
+    deps = [],
+)
+
+bzl_library(
     name = "tokens",
     srcs = ["tokens.bzl"],
     visibility = ["//spm:__subpackages__"],

--- a/spm/internal/modulemap_parser/BUILD.bazel
+++ b/spm/internal/modulemap_parser/BUILD.bazel
@@ -6,3 +6,12 @@ bzl_library(
     visibility = ["//spm:__subpackages__"],
     deps = [],
 )
+
+bzl_library(
+    name = "tokenizer",
+    srcs = ["tokenizer.bzl"],
+    visibility = ["//spm:__subpackages__"],
+    deps = [
+        ":tokens",
+    ],
+)

--- a/spm/internal/modulemap_parser/BUILD.bazel
+++ b/spm/internal/modulemap_parser/BUILD.bazel
@@ -15,3 +15,12 @@ bzl_library(
         ":tokens",
     ],
 )
+
+bzl_library(
+    name = "parser",
+    srcs = ["parser.bzl"],
+    visibility = ["//spm:__subpackages__"],
+    deps = [
+        ":tokenizer",
+    ],
+)

--- a/spm/internal/modulemap_parser/BUILD.bazel
+++ b/spm/internal/modulemap_parser/BUILD.bazel
@@ -1,10 +1,19 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 bzl_library(
+    name = "errors",
+    srcs = ["errors.bzl"],
+    visibility = ["//spm:__subpackages__"],
+    deps = [],
+)
+
+bzl_library(
     name = "tokens",
     srcs = ["tokens.bzl"],
     visibility = ["//spm:__subpackages__"],
-    deps = [],
+    deps = [
+        ":errors",
+    ],
 )
 
 bzl_library(
@@ -21,6 +30,8 @@ bzl_library(
     srcs = ["parser.bzl"],
     visibility = ["//spm:__subpackages__"],
     deps = [
+        ":errors",
         ":tokenizer",
+        ":tokens",
     ],
 )

--- a/spm/internal/modulemap_parser/character_sets.bzl
+++ b/spm/internal/modulemap_parser/character_sets.bzl
@@ -1,0 +1,22 @@
+load("@bazel_skylib//lib:sets.bzl", "sets")
+
+_whitespaces = sets.make([
+    " ",  # space
+    "\t",  # horizontal tab
+    # "\\v",  # vertical tab
+    # "\\b",  # backspace
+])
+
+_newlines = sets.make([
+    "\n",  # line feed
+    "\r",  # carriage return
+    # "\\f",  # form feed
+])
+
+_operators = sets.make(["*"])
+
+character_sets = struct(
+    whitespaces = _whitespaces,
+    newlines = _newlines,
+    operators = _operators,
+)

--- a/spm/internal/modulemap_parser/character_sets.bzl
+++ b/spm/internal/modulemap_parser/character_sets.bzl
@@ -13,8 +13,6 @@ _newlines = sets.make([
     # "\\f",  # form feed
 ])
 
-_operators = sets.make(["*"])
-
 _non_zero_decimal_digits = sets.make([
     "1",
     "2",
@@ -89,6 +87,8 @@ _uppercase_letters = sets.make([
 
 _letters = sets.union(_lowercase_letters, _uppercase_letters)
 
+_c99_operators = sets.make(["*"])
+
 _c99_identifier_beginning_characters = sets.union(_letters, sets.make(["_"]))
 
 _c99_identifier_characters = sets.union(_c99_identifier_beginning_characters, _decimal_digits)
@@ -96,12 +96,12 @@ _c99_identifier_characters = sets.union(_c99_identifier_beginning_characters, _d
 character_sets = struct(
     whitespaces = _whitespaces,
     newlines = _newlines,
-    operators = _operators,
     lowercase_letters = _lowercase_letters,
     uppercase_letters = _uppercase_letters,
     letters = _letters,
     non_zero_decimal_digits = _non_zero_decimal_digits,
     decimal_digits = _decimal_digits,
+    c99_operators = _c99_operators,
     c99_identifier_beginning_characters = _c99_identifier_beginning_characters,
     c99_identifier_characters = _c99_identifier_characters,
 )

--- a/spm/internal/modulemap_parser/character_sets.bzl
+++ b/spm/internal/modulemap_parser/character_sets.bzl
@@ -15,8 +15,87 @@ _newlines = sets.make([
 
 _operators = sets.make(["*"])
 
+_non_zero_decimal_digits = sets.make([
+    "1",
+    "2",
+    "3",
+    "4",
+    "5",
+    "6",
+    "7",
+    "8",
+    "9",
+])
+
+_decimal_digits = sets.union(_non_zero_decimal_digits, sets.make(["0"]))
+
+_lowercase_letters = sets.make([
+    "a",
+    "b",
+    "c",
+    "d",
+    "e",
+    "f",
+    "g",
+    "h",
+    "i",
+    "j",
+    "k",
+    "l",
+    "m",
+    "n",
+    "o",
+    "p",
+    "q",
+    "r",
+    "s",
+    "t",
+    "u",
+    "v",
+    "w",
+    "x",
+    "y",
+    "z",
+])
+
+_uppercase_letters = sets.make([
+    "A",
+    "B",
+    "C",
+    "D",
+    "E",
+    "F",
+    "G",
+    "H",
+    "I",
+    "J",
+    "K",
+    "L",
+    "M",
+    "N",
+    "O",
+    "P",
+    "Q",
+    "R",
+    "S",
+    "T",
+    "U",
+    "V",
+    "W",
+    "X",
+    "Y",
+    "Z",
+])
+
+_letters = sets.union(_lowercase_letters, _uppercase_letters)
+
 character_sets = struct(
     whitespaces = _whitespaces,
     newlines = _newlines,
     operators = _operators,
+    lowercase_letters = _lowercase_letters,
+    uppercase_letters = _uppercase_letters,
+    letters = _letters,
+    non_zero_decimal_digits = _non_zero_decimal_digits,
+    decimal_digits = _decimal_digits,
 )

--- a/spm/internal/modulemap_parser/character_sets.bzl
+++ b/spm/internal/modulemap_parser/character_sets.bzl
@@ -93,6 +93,27 @@ _c99_identifier_beginning_characters = sets.union(_letters, sets.make(["_"]))
 
 _c99_identifier_characters = sets.union(_c99_identifier_beginning_characters, _decimal_digits)
 
+_c99_hexadecimal_characters = sets.union(_decimal_digits, sets.make([
+    "a",
+    "b",
+    "c",
+    "d",
+    "e",
+    "f",
+    "A",
+    "B",
+    "C",
+    "D",
+    "E",
+    "F",
+]))
+
+_c99_number_characters = sets.union(
+    _decimal_digits,
+    _c99_hexadecimal_characters,
+    sets.make(["x", "X", "."]),
+)
+
 character_sets = struct(
     whitespaces = _whitespaces,
     newlines = _newlines,
@@ -104,4 +125,6 @@ character_sets = struct(
     c99_operators = _c99_operators,
     c99_identifier_beginning_characters = _c99_identifier_beginning_characters,
     c99_identifier_characters = _c99_identifier_characters,
+    c99_hexadecimal_characters = _c99_hexadecimal_characters,
+    c99_number_characters = _c99_number_characters,
 )

--- a/spm/internal/modulemap_parser/character_sets.bzl
+++ b/spm/internal/modulemap_parser/character_sets.bzl
@@ -89,6 +89,10 @@ _uppercase_letters = sets.make([
 
 _letters = sets.union(_lowercase_letters, _uppercase_letters)
 
+_c99_identifier_beginning_characters = sets.union(_letters, sets.make(["_"]))
+
+_c99_identifier_characters = sets.union(_c99_identifier_beginning_characters, _decimal_digits)
+
 character_sets = struct(
     whitespaces = _whitespaces,
     newlines = _newlines,
@@ -98,4 +102,6 @@ character_sets = struct(
     letters = _letters,
     non_zero_decimal_digits = _non_zero_decimal_digits,
     decimal_digits = _decimal_digits,
+    c99_identifier_beginning_characters = _c99_identifier_beginning_characters,
+    c99_identifier_characters = _c99_identifier_characters,
 )

--- a/spm/internal/modulemap_parser/collect_export_declaration.bzl
+++ b/spm/internal/modulemap_parser/collect_export_declaration.bzl
@@ -1,6 +1,6 @@
 load(":collection_results.bzl", "collection_results")
 load(":errors.bzl", "errors")
-load(":tokens.bzl", "tokens", rws = "reserved_words", tts = "token_types")
+load(":tokens.bzl", "tokens", ops = "operators", rws = "reserved_words", tts = "token_types")
 load(":declarations.bzl", "declarations")
 
 def collect_export_declaration(parsed_tokens):
@@ -28,8 +28,41 @@ def collect_export_declaration(parsed_tokens):
     consumed_count = 0
     collect_result = None
 
+    export_token, err = tokens.get_as(parsed_tokens, 0, tts.reserved, rws.export, count = tlen)
+    if err != None:
+        return None, err
+    consumed_count += 1
+
+    wildcard = False
+    identifiers = []
     for idx in range(consumed_count, tlen - consumed_count):
         consumed_count += 1
 
-    decl = declarations.export
+        # Get next token
+        token, err = tokens.get(parsed_tokens, idx, count = tlen)
+        if err != None:
+            return None, err
+
+        if tokens.is_a(token, tts.operator, ops.asterisk):
+            wildcard = True
+            break
+
+        elif tokens.is_a(token, tts.identifier):
+            identifiers.append(token.value)
+
+        elif tokens.is_a(token, tts.period):
+            pass
+
+        elif tokens.is_a(token, tts.newline):
+            break
+
+        else:
+            return None, errors.new(
+                "Unexpected token collecting export declaration. token: %s" % (token),
+            )
+
+    decl = declarations.export(
+        identifiers = identifiers,
+        wildcard = wildcard,
+    )
     return collection_results.new([decl], consumed_count), None

--- a/spm/internal/modulemap_parser/collect_export_declaration.bzl
+++ b/spm/internal/modulemap_parser/collect_export_declaration.bzl
@@ -1,3 +1,8 @@
+load(":collection_results.bzl", "collection_results")
+load(":errors.bzl", "errors")
+load(":tokens.bzl", "tokens", rws = "reserved_words", tts = "token_types")
+load(":declarations.bzl", "declarations")
+
 def collect_export_declaration(parsed_tokens):
     """Collect export declaration.
 
@@ -19,4 +24,12 @@ def collect_export_declaration(parsed_tokens):
         A `tuple` where the first item is the collection result and the second is an
         error `struct` as returned from errors.create().
     """
-    pass
+    tlen = len(parsed_tokens)
+    consumed_count = 0
+    collect_result = None
+
+    for idx in range(consumed_count, tlen - consumed_count):
+        consumed_count += 1
+
+    decl = declarations.export
+    return collection_results.new([decl], consumed_count), None

--- a/spm/internal/modulemap_parser/collect_export_declaration.bzl
+++ b/spm/internal/modulemap_parser/collect_export_declaration.bzl
@@ -1,0 +1,22 @@
+def collect_export_declaration(parsed_tokens):
+    """Collect export declaration.
+
+    Spec: https://clang.llvm.org/docs/Modules.html#export-declaration
+
+    Syntax:
+        export-declaration:
+          export wildcard-module-id
+
+        wildcard-module-id:
+          identifier
+          '*'
+          identifier '.' wildcard-module-id
+
+    Args:
+        parsed_tokens: A `list` of tokens.
+
+    Returns:
+        A `tuple` where the first item is the collection result and the second is an
+        error `struct` as returned from errors.create().
+    """
+    pass

--- a/spm/internal/modulemap_parser/collect_extern_module.bzl
+++ b/spm/internal/modulemap_parser/collect_extern_module.bzl
@@ -1,9 +1,6 @@
 load(":collection_results.bzl", "collection_results")
 load(":declarations.bzl", "declarations")
-load(":tokens.bzl", "reserved_words", "tokens")
-
-tts = tokens.types
-rws = reserved_words
+load(":tokens.bzl", "tokens", rws = "reserved_words", tts = "token_types")
 
 def collect_extern_module(parsed_tokens):
     """Collect an extern module declaration.

--- a/spm/internal/modulemap_parser/collect_extern_module.bzl
+++ b/spm/internal/modulemap_parser/collect_extern_module.bzl
@@ -1,0 +1,43 @@
+load(":declarations.bzl", "declarations")
+load(":tokens.bzl", "reserved_words", "tokens")
+load(":collection_results.bzl", "collection_results")
+
+tts = tokens.types
+rws = reserved_words
+
+def collect_extern_module(parsed_tokens):
+    """Collect an extern module declaration.
+
+    Spec: https://clang.llvm.org/docs/Modules.html#module-declaration
+
+    Syntax:
+
+    extern module module-id string-literal
+
+    Args:
+        parsed_tokens: A `list` of tokens.
+
+    Returns:
+        A `tuple` where the first item is the collection result and the second is an
+        error `struct` as returned from errors.create().
+    """
+
+    tlen = len(parsed_tokens)
+    extern_token, err = tokens.get_as(parsed_tokens, 0, tts.reserved, rws.extern, count = tlen)
+    if err:
+        return None, err
+
+    module_token, err = tokens.get_as(parsed_tokens, 1, tts.reserved, rws.module, count = tlen)
+    if err:
+        return None, err
+
+    module_id_token, err = tokens.get_as(parsed_tokens, 2, tts.identifier, count = tlen)
+    if err:
+        return None, err
+
+    path_token, err = tokens.get_as(parsed_tokens, 3, tts.string_literal, count = tlen)
+    if err:
+        return None, err
+
+    decl = declarations.extern_module(module_id_token.value, path_token.value)
+    return collection_results.new([decl], 4), None

--- a/spm/internal/modulemap_parser/collect_extern_module.bzl
+++ b/spm/internal/modulemap_parser/collect_extern_module.bzl
@@ -1,6 +1,6 @@
+load(":collection_results.bzl", "collection_results")
 load(":declarations.bzl", "declarations")
 load(":tokens.bzl", "reserved_words", "tokens")
-load(":collection_results.bzl", "collection_results")
 
 tts = tokens.types
 rws = reserved_words
@@ -12,7 +12,7 @@ def collect_extern_module(parsed_tokens):
 
     Syntax:
 
-    extern module module-id string-literal
+        extern module module-id string-literal
 
     Args:
         parsed_tokens: A `list` of tokens.

--- a/spm/internal/modulemap_parser/collect_header_declaration.bzl
+++ b/spm/internal/modulemap_parser/collect_header_declaration.bzl
@@ -35,24 +35,20 @@ def collect_header_declaration(parsed_tokens, prefix_tokens):
     private = False
     textual = False
 
-    prefix_tokens_count = len(prefix_tokens)
-    if prefix_tokens_count > 0:
-        token = prefix_tokens[0]
+    for token in prefix_tokens:
         if tokens.is_a(token, tts.reserved, rws.umbrella):
             decl_type = dts.umbrella_header
         elif tokens.is_a(token, tts.reserved, rws.exclude):
             decl_type = dts.exclude_header
+        elif tokens.is_a(token, tts.reserved, rws.private):
+            private = True
+        elif tokens.is_a(token, tts.reserved, rws.textual):
+            textual = True
         else:
-            for token in prefix_tokens:
-                if tokens.is_a(token, tts.reserved, rws.private):
-                    private = True
-                elif tokens.is_a(token, tts.reserved, rws.textual):
-                    textual = True
-                else:
-                    return None, errors.new(
-                        "Unexpected token processing header declaration prefix tokens. token: %s" %
-                        (token),
-                    )
+            return None, errors.new(
+                "Unexpected token processing header declaration prefix tokens. token: %s" %
+                (token),
+            )
 
     consumed_count = 0
 

--- a/spm/internal/modulemap_parser/collect_header_declaration.bzl
+++ b/spm/internal/modulemap_parser/collect_header_declaration.bzl
@@ -36,18 +36,20 @@ def collect_header_declaration(parsed_tokens, prefix_tokens):
     textual = False
 
     prefix_tokens_count = len(prefix_tokens)
+
+    # DEBUG BEGIN
+    print("*** CHUCK prefix_tokens: ", prefix_tokens)
+    print("*** CHUCK prefix_tokens_count: ", prefix_tokens_count)
+
+    # DEBUG END
     if prefix_tokens_count > 0:
         token = prefix_tokens[0]
-
-        # TODO: Create tokens.is_a(...)
-        # if tokens.is_a(token, tts.reserved, rws.umbrella):
-
         if tokens.is_a(token, tts.reserved, rws.umbrella):
             decl_type = dts.umbrella_header
-        elif tokens.is_a(token, tts.reserved, token.value, rws.exclude):
+        elif tokens.is_a(token, tts.reserved, rws.exclude):
             decl_type = dts.exclude_header
-        elif prefix_tokens_count > 1:
-            for token in prefix_tokens[1:]:
+        else:
+            for token in prefix_tokens:
                 if tokens.is_a(token, tts.reserved, rws.private):
                     private = True
                 elif tokens.is_a(token, tts.reserved, rws.textual):

--- a/spm/internal/modulemap_parser/collect_header_declaration.bzl
+++ b/spm/internal/modulemap_parser/collect_header_declaration.bzl
@@ -1,6 +1,7 @@
 load(":errors.bzl", "errors")
 load(":collection_results.bzl", "collection_results")
-load(":tokens.bzl", "reserved_words", "tokens")
+load(":tokens.bzl", "tokens", rws = "reserved_words", tts = "token_types")
+load(":declarations.bzl", "declarations", dts = "declaration_types")
 
 def collect_header_declaration(parsed_tokens, prefix_tokens):
     """Collect a header declaration.
@@ -28,4 +29,53 @@ def collect_header_declaration(parsed_tokens, prefix_tokens):
         A `tuple` where the first item is the collection result and the second is an
         error `struct` as returned from errors.create().
     """
+    tlen = len(parsed_tokens)
+
+    decl_type = dts.single_header
+    private = False
+    textual = False
+
+    prefix_tokens_count = len(prefix_tokens)
+    if prefix_tokens_count > 0:
+        token = prefix_tokens[0]
+
+        # TODO: Create tokens.is_a(...)
+        # if tokens.is_a(token, tts.reserved, rws.umbrella):
+
+        if token.type == tts.reserved and token.value == rws.umbrella:
+            decl_type = dts.umbrella_header
+        elif token.type == tts.reserved and token.value == rws.exclude:
+            decl_type = dts.exclude_header
+        elif prefix_tokens_count > 1:
+            for token in prefix_tokens[1:]:
+                if token.type == tts.reserved and token.value == rws.private:
+                    private = True
+                elif token.type == tts.reserved and token.value == rws.textual:
+                    textual = False
+                else:
+                    return None, errors.new(
+                        "Unexpected token processing header declaration prefix tokens. token: %s" %
+                        (token),
+                    )
+
+    consumed_count = 0
+
+    header_token, err = tokens.get_as(parsed_tokens, 0, tts.reserved, rws.header, count = tlen)
+    if err != None:
+        return None, err
+    consumed_count += 1
+
+    path_token, err = tokens.get_as(parsed_tokens, 1, tts.string_literal, count = tlen)
+    if err != None:
+        return None, err
+    consumed_count += 1
+
+    for idx in range(consumed_count, tlen - consumed_count):
+        consumed_count += 1
+
+        # Get next token
+        token, err = tokens.get(parsed_tokens, idx, count = tlen)
+        if err != None:
+            return None, err
+
     return None, errors.new("IMPLEMEMT ME!")

--- a/spm/internal/modulemap_parser/collect_header_declaration.bzl
+++ b/spm/internal/modulemap_parser/collect_header_declaration.bzl
@@ -36,12 +36,6 @@ def collect_header_declaration(parsed_tokens, prefix_tokens):
     textual = False
 
     prefix_tokens_count = len(prefix_tokens)
-
-    # DEBUG BEGIN
-    print("*** CHUCK prefix_tokens: ", prefix_tokens)
-    print("*** CHUCK prefix_tokens_count: ", prefix_tokens_count)
-
-    # DEBUG END
     if prefix_tokens_count > 0:
         token = prefix_tokens[0]
         if tokens.is_a(token, tts.reserved, rws.umbrella):
@@ -53,7 +47,7 @@ def collect_header_declaration(parsed_tokens, prefix_tokens):
                 if tokens.is_a(token, tts.reserved, rws.private):
                     private = True
                 elif tokens.is_a(token, tts.reserved, rws.textual):
-                    textual = False
+                    textual = True
                 else:
                     return None, errors.new(
                         "Unexpected token processing header declaration prefix tokens. token: %s" %

--- a/spm/internal/modulemap_parser/collect_header_declaration.bzl
+++ b/spm/internal/modulemap_parser/collect_header_declaration.bzl
@@ -1,0 +1,30 @@
+load(":errors.bzl", "errors")
+load(":collection_results.bzl", "collection_results")
+load(":tokens.bzl", "reserved_words", "tokens")
+
+def collect_header_declaration(parsed_tokens):
+    """Collect a header declaration.
+
+    Spec: https://clang.llvm.org/docs/Modules.html#header-declaration
+
+    Syntax:
+        header-declaration:
+          privateopt textualopt header string-literal header-attrsopt
+          umbrella header string-literal header-attrsopt
+          exclude header string-literal header-attrsopt
+
+        header-attrs:
+          '{' header-attr* '}'
+
+        header-attr:
+          size integer-literal
+          mtime integer-literal
+
+    Args:
+        parsed_tokens: A `list` of tokens.
+
+    Returns:
+        A `tuple` where the first item is the collection result and the second is an
+        error `struct` as returned from errors.create().
+    """
+    return None, errors.new("IMPLEMEMT ME!")

--- a/spm/internal/modulemap_parser/collect_header_declaration.bzl
+++ b/spm/internal/modulemap_parser/collect_header_declaration.bzl
@@ -2,7 +2,7 @@ load(":errors.bzl", "errors")
 load(":collection_results.bzl", "collection_results")
 load(":tokens.bzl", "reserved_words", "tokens")
 
-def collect_header_declaration(parsed_tokens):
+def collect_header_declaration(parsed_tokens, prefix_tokens):
     """Collect a header declaration.
 
     Spec: https://clang.llvm.org/docs/Modules.html#header-declaration
@@ -22,6 +22,7 @@ def collect_header_declaration(parsed_tokens):
 
     Args:
         parsed_tokens: A `list` of tokens.
+        prefix_tokens: A `list` of tokens that have been consumed but not yet processed.
 
     Returns:
         A `tuple` where the first item is the collection result and the second is an

--- a/spm/internal/modulemap_parser/collect_module.bzl
+++ b/spm/internal/modulemap_parser/collect_module.bzl
@@ -116,11 +116,13 @@ def collect_module(parsed_tokens, is_submodule = False, prefix_tokens = []):
             if err != None:
                 return None, err
             members.extend(collect_result.declarations)
+
         elif token.type == tts.square_bracket_open:
             collect_result, err = _collect_attribute(parsed_tokens[idx:])
             if err != None:
                 return None, err
             attributes.extend(collect_result.declarations)
+
         else:
             return None, errors.new(
                 "Unexpected token collecting attributes and module members. token: %s" % (token),

--- a/spm/internal/modulemap_parser/collect_module.bzl
+++ b/spm/internal/modulemap_parser/collect_module.bzl
@@ -111,13 +111,13 @@ def collect_module(parsed_tokens, is_submodule = False, prefix_tokens = []):
             return None, err
 
         # Process the token
-        if token.type == tts.curly_bracket_open:
+        if tokens.is_a(token, tts.curly_bracket_open):
             collect_result, err = collect_module_members(parsed_tokens[idx:])
             if err != None:
                 return None, err
             members.extend(collect_result.declarations)
 
-        elif token.type == tts.square_bracket_open:
+        elif tokens.is_a(token, tts.square_bracket_open):
             collect_result, err = _collect_attribute(parsed_tokens[idx:])
             if err != None:
                 return None, err

--- a/spm/internal/modulemap_parser/collect_module.bzl
+++ b/spm/internal/modulemap_parser/collect_module.bzl
@@ -105,6 +105,9 @@ def collect_module(parsed_tokens, is_submodule = False, prefix_tokens = []):
             skip_ahead -= 1
             continue
 
+        collect_result = None
+        err = None
+
         # Get next token
         token, err = tokens.get(parsed_tokens, idx, count = tlen)
         if err != None:

--- a/spm/internal/modulemap_parser/collect_module.bzl
+++ b/spm/internal/modulemap_parser/collect_module.bzl
@@ -113,18 +113,20 @@ def collect_module(parsed_tokens, is_submodule = False, prefix_tokens = []):
         # Process the token
         if token.type == tts.curly_bracket_open:
             collect_result, err = collect_module_members(parsed_tokens[idx:])
+            if err != None:
+                return None, err
             members.extend(collect_result.declarations)
         elif token.type == tts.square_bracket_open:
             collect_result, err = _collect_attribute(parsed_tokens[idx:])
+            if err != None:
+                return None, err
             attributes.extend(collect_result.declarations)
         else:
             return None, errors.new(
                 "Unexpected token collecting attributes and module members. token: %s" % (token),
             )
 
-        # Handle any errors and index advancement.
-        if err != None:
-            return None, err
+        # Handle index advancement.
         if collect_result:
             skip_ahead = collect_result.count - 1
 

--- a/spm/internal/modulemap_parser/collect_module.bzl
+++ b/spm/internal/modulemap_parser/collect_module.bzl
@@ -9,7 +9,7 @@ rws = reserved_words
 def _collect_attribute(parsed_tokens):
     tlen = len(parsed_tokens)
 
-    open_token, err = tokens.get_as(parsed_tokens, 0, tts.curly_bracket_open, count = tlen)
+    open_token, err = tokens.get_as(parsed_tokens, 0, tts.square_bracket_open, count = tlen)
     if err != None:
         return None, err
 
@@ -17,11 +17,11 @@ def _collect_attribute(parsed_tokens):
     if err != None:
         return None, err
 
-    open_token, err = tokens.get_as(parsed_tokens, 2, tts.curly_bracket_close, count = tlen)
+    open_token, err = tokens.get_as(parsed_tokens, 2, tts.square_bracket_close, count = tlen)
     if err != None:
         return None, err
 
-    return collection_results.new([attrib_token.value], 3)
+    return collection_results.new([attrib_token.value], 3), None
 
 def collect_module(parsed_tokens, is_submodule = False, prefix_tokens = []):
     """Collect a module declaration.
@@ -56,7 +56,7 @@ def collect_module(parsed_tokens, is_submodule = False, prefix_tokens = []):
                 return None, errors.new("The explicit qualifier can only exist on submodules.")
             explicit = True
 
-        elif token.type == tts.reserved and token.value == rws.framewor:
+        elif token.type == tts.reserved and token.value == rws.framework:
             framework = True
 
         else:

--- a/spm/internal/modulemap_parser/collect_module.bzl
+++ b/spm/internal/modulemap_parser/collect_module.bzl
@@ -1,0 +1,111 @@
+load(":collection_results.bzl", "collection_results")
+load(":declarations.bzl", "declarations")
+load(":errors.bzl", "errors")
+load(":tokens.bzl", "reserved_words", "tokens")
+
+tts = tokens.types
+rws = reserved_words
+
+def _collect_attribute(parsed_tokens):
+    tlen = len(parsed_tokens)
+
+    open_token, err = tokens.get_as(parsed_tokens, 0, tts.curly_bracket_open, count = tlen)
+    if err != None:
+        return None, err
+
+    attrib_token, err = tokens.get_as(parsed_tokens, 1, tts.identifier, count = tlen)
+    if err != None:
+        return None, err
+
+    open_token, err = tokens.get_as(parsed_tokens, 2, tts.curly_bracket_close, count = tlen)
+    if err != None:
+        return None, err
+
+    return collection_results.new([attrib_token.value], 3)
+
+def collect_module(parsed_tokens, is_submodule = False, prefix_tokens = []):
+    """Collect a module declaration.
+
+    Spec: https://clang.llvm.org/docs/Modules.html#module-declaration
+
+    Syntax:
+
+        explicitopt frameworkopt module module-id attributesopt '{' module-member* '}'
+
+    Args:
+        parsed_tokens: A `list` of tokens.
+        is_submodule: A `bool` that designates whether the module is a child of another module.
+        prefix_tokens: A `list` of tokens that have already been collected, but not applied.
+
+    Returns:
+        A `tuple` where the first item is the collection result and the second is an
+        error `struct` as returned from errors.create().
+    """
+    explicit = False
+    framework = False
+    attributes = []
+    members = []
+    consumed_count = 0
+
+    tlen = len(parsed_tokens)
+
+    # Process the prefix tokens
+    for token in prefix_tokens:
+        if token.type == tts.reserved and token.value == rws.explicit:
+            if not is_submodule:
+                return None, errors.new("The explicit qualifier can only exist on submodules.")
+            explicit = True
+
+        elif token.type == tts.reserved and token.value == rws.framewor:
+            framework = True
+
+        else:
+            return None, errors.new(
+                "Unexpected prefix token collecting module declaration. token: %s" % (token),
+            )
+
+    module_token, err = tokens.get_as(parsed_tokens, 0, tts.reserved, rws.module, count = tlen)
+    if err != None:
+        return None, err
+    consumed_count += 1
+
+    module_id_token, err = tokens.get_as(parsed_tokens, 1, tts.identifier, count = tlen)
+    if err != None:
+        return None, err
+    consumed_count += 1
+
+    # Collect the attributes
+    skip_ahead = 0
+    collect_result = None
+    for idx in range(consumed_count, tlen - consumed_count):
+        consumed_count += 1
+        if skip_ahead > 0:
+            skip_ahead -= 1
+            continue
+
+        token, err = tokens.get(parsed_tokens, idx, count = tlen)
+        if err != None:
+            return None, err
+
+        if token.type == tts.curly_bracket_open:
+            break
+        elif token.type == tts.square_bracket_open:
+            collect_result, err = _collect_attribute(parsed_tokens[idx:])
+        else:
+            return None, errors.new("Unexpected token collecting attributes. token: %s" % (token))
+
+        if err != None:
+            return None, err
+        if collect_result:
+            attributes.extend(collect_result.declarations)
+            skip_ahead = collect_result.count - 1
+
+    # Create the declaration
+    decl = declarations.module(
+        module_id = module_id_token.value,
+        explicit = explicit,
+        framework = framework,
+        attributes = attributes,
+        members = members,
+    )
+    return collection_results.new([decl], consumed_count), None

--- a/spm/internal/modulemap_parser/collect_module.bzl
+++ b/spm/internal/modulemap_parser/collect_module.bzl
@@ -2,10 +2,7 @@ load(":collection_results.bzl", "collection_results")
 load(":collect_module_members.bzl", "collect_module_members")
 load(":declarations.bzl", "declarations")
 load(":errors.bzl", "errors")
-load(":tokens.bzl", "reserved_words", "tokens")
-
-tts = tokens.types
-rws = reserved_words
+load(":tokens.bzl", "tokens", rws = "reserved_words", tts = "token_types")
 
 # MARK: - Attribute Collection
 

--- a/spm/internal/modulemap_parser/collect_module_members.bzl
+++ b/spm/internal/modulemap_parser/collect_module_members.bzl
@@ -37,6 +37,8 @@ def collect_module_members(parsed_tokens):
             skip_ahead -= 1
             continue
 
+        collect_result = None
+
         # Get next token
         token, err = tokens.get(parsed_tokens, idx, count = tlen)
         if err != None:

--- a/spm/internal/modulemap_parser/collect_module_members.bzl
+++ b/spm/internal/modulemap_parser/collect_module_members.bzl
@@ -26,8 +26,23 @@ def collect_module_members(parsed_tokens):
 
         # Process token
 
-        if token.type == tts.newline:
+        if token.type == tts.curly_bracket_close:
+            if len(prefix_tokens) > 0:
+                return None, errors.new(
+                    "Unexpected prefix tokens found at end of module member block.",
+                )
+            break
+
+        elif token.type == tts.newline:
             if len(prefix_tokens) > 0:
                 return None, errors.new("Unexpected prefix tokens found before end of line.")
+
+        # else:
+        #     # Store any unrecognized tokens as prefix tokens to be processed later
+        #     prefix_tokens.append(token)
+
+        # Handle index advancement.
+        if collect_result:
+            skip_ahead = collect_result.count - 1
 
     return collection_results.new(members, consumed_count), None

--- a/spm/internal/modulemap_parser/collect_module_members.bzl
+++ b/spm/internal/modulemap_parser/collect_module_members.bzl
@@ -58,7 +58,7 @@ def collect_module_members(parsed_tokens):
         elif tokens.is_a(token, tts.newline):
             if len(prefix_tokens) > 0:
                 return None, errors.new(
-                    "Unexpected prefix tokens found before end of line. tokens: %" % (prefix_tokens),
+                    "Unexpected prefix tokens found before end of line. tokens: %s" % (prefix_tokens),
                 )
 
         elif tokens.is_a(token, tts.reserved, rws.umbrella):

--- a/spm/internal/modulemap_parser/collect_module_members.bzl
+++ b/spm/internal/modulemap_parser/collect_module_members.bzl
@@ -41,16 +41,20 @@ def collect_module_members(parsed_tokens):
         if token.type == tts.curly_bracket_close:
             if len(prefix_tokens) > 0:
                 return None, errors.new(
-                    "Unexpected prefix tokens found at end of module member block.",
+                    "Unexpected prefix tokens found at end of module member block. tokens: %s" %
+                    (prefix_tokens),
                 )
             break
 
         elif token.type == tts.newline:
             if len(prefix_tokens) > 0:
-                return None, errors.new("Unexpected prefix tokens found before end of line.")
+                return None, errors.new(
+                    "Unexpected prefix tokens found before end of line. tokens: %" % (prefix_tokens),
+                )
 
         elif token.type == tts.reserved and token.value == rws.header:
             collect_result, err = collect_header_declaration(parsed_tokens[idx:], prefix_tokens)
+            prefix_tokens = []
 
         elif token.type == tts.reserved and sets.contains(_unsupported_module_members, token.value):
             return None, errors.new("Unsupported module member token. token: %s" % (token))

--- a/spm/internal/modulemap_parser/collect_module_members.bzl
+++ b/spm/internal/modulemap_parser/collect_module_members.bzl
@@ -1,11 +1,8 @@
 load(":collection_results.bzl", "collection_results")
 load(":errors.bzl", "errors")
-load(":tokens.bzl", "reserved_words", "tokens")
+load(":tokens.bzl", "tokens", rws = "reserved_words", tts = "token_types")
 load("@bazel_skylib//lib:sets.bzl", "sets")
 load(":collect_header_declaration.bzl", "collect_header_declaration")
-
-tts = tokens.types
-rws = reserved_words
 
 _unsupported_module_members = sets.make([
     rws.config_macros,

--- a/spm/internal/modulemap_parser/collect_module_members.bzl
+++ b/spm/internal/modulemap_parser/collect_module_members.bzl
@@ -53,7 +53,7 @@ def collect_module_members(parsed_tokens):
                 return None, errors.new("Unexpected prefix tokens found before end of line.")
 
         elif token.type == tts.reserved and token.value == rws.header:
-            collect_result, err = collect_header_declaration(parsed_tokens[idx:])
+            collect_result, err = collect_header_declaration(parsed_tokens[idx:], prefix_tokens)
 
         elif token.type == tts.reserved and sets.contains(_unsupported_module_members, token.value):
             return None, errors.new("Unsupported module member token. token: %s" % (token))

--- a/spm/internal/modulemap_parser/collect_module_members.bzl
+++ b/spm/internal/modulemap_parser/collect_module_members.bzl
@@ -9,6 +9,9 @@ rws = reserved_words
 _unsupported_module_members = sets.make([
     rws.config_macros,
     rws.conflict,
+    rws.requires,
+    rws.use,
+    rws.link,
 ])
 
 def collect_module_members(parsed_tokens):

--- a/spm/internal/modulemap_parser/collect_module_members.bzl
+++ b/spm/internal/modulemap_parser/collect_module_members.bzl
@@ -1,0 +1,33 @@
+load(":collection_results.bzl", "collection_results")
+load(":errors.bzl", "errors")
+load(":tokens.bzl", "reserved_words", "tokens")
+
+tts = tokens.types
+rws = reserved_words
+
+def collect_module_members(parsed_tokens):
+    tlen = len(parsed_tokens)
+    members = []
+    consumed_count = 0
+
+    skip_ahead = 0
+    collect_result = None
+    prefix_tokens = []
+    for idx in range(tlen):
+        consumed_count += 1
+        if skip_ahead > 0:
+            skip_ahead -= 1
+            continue
+
+        # Get next token
+        token, err = tokens.get(parsed_tokens, idx, count = tlen)
+        if err != None:
+            return None, err
+
+        # Process token
+
+        if token.type == tts.newline:
+            if len(prefix_tokens) > 0:
+                return None, errors.new("Unexpected prefix tokens found before end of line.")
+
+    return collection_results.new(members, consumed_count), None

--- a/spm/internal/modulemap_parser/collect_module_members.bzl
+++ b/spm/internal/modulemap_parser/collect_module_members.bzl
@@ -1,8 +1,9 @@
+load(":collect_header_declaration.bzl", "collect_header_declaration")
+load(":collect_umbrella_dir_declaration.bzl", "collect_umbrella_dir_declaration")
 load(":collection_results.bzl", "collection_results")
 load(":errors.bzl", "errors")
 load(":tokens.bzl", "tokens", rws = "reserved_words", tts = "token_types")
 load("@bazel_skylib//lib:sets.bzl", "sets")
-load(":collect_header_declaration.bzl", "collect_header_declaration")
 
 _unsupported_module_members = sets.make([
     rws.config_macros,
@@ -28,7 +29,8 @@ def collect_module_members(parsed_tokens):
     for idx in range(consumed_count, tlen - consumed_count):
         # TODO: Make sure that we are counting consumed tokens correctly. I
         # think we may be double counting when we come back from collection
-        # functions (e.g. return collect_result).
+        # functions (e.g. return collect_result). I think that is why I
+        # subtract 1 when calculating the skip_ahead below.
 
         consumed_count += 1
         if skip_ahead > 0:
@@ -55,6 +57,25 @@ def collect_module_members(parsed_tokens):
                 return None, errors.new(
                     "Unexpected prefix tokens found before end of line. tokens: %" % (prefix_tokens),
                 )
+
+        elif tokens.is_a(token, tts.reserved, rws.umbrella):
+            # The umbrella word can appear for umbrella headers or umbrella directories.
+            # If the next token is header, then it is an umbrella header. Otherwise, it is an umbrella
+            # directory.
+            next_idx = idx + 1
+            next_token, err = tokens.get(parsed_tokens, next_idx, count = tlen)
+            if err != None:
+                return None, err
+            if tokens.is_a(next_token, tts.reserved, rws.header):
+                prefix_tokens.append(token)
+
+            else:
+                if len(prefix_tokens) > 0:
+                    return None, errors.new(
+                        "Unexpected prefix tokens found before end of line. tokens: %" %
+                        (prefix_tokens),
+                    )
+                collect_result, err = collect_umbrella_dir_declaration(parsed_tokens[idx:])
 
         elif tokens.is_a(token, tts.reserved, rws.header):
             collect_result, err = collect_header_declaration(parsed_tokens[idx:], prefix_tokens)

--- a/spm/internal/modulemap_parser/collect_module_members.bzl
+++ b/spm/internal/modulemap_parser/collect_module_members.bzl
@@ -10,10 +10,15 @@ def collect_module_members(parsed_tokens):
     members = []
     consumed_count = 0
 
+    open_members_token, err = tokens.get_as(parsed_tokens, 0, tts.curly_bracket_open, count = tlen)
+    if err != None:
+        return None, err
+    consumed_count += 1
+
     skip_ahead = 0
     collect_result = None
     prefix_tokens = []
-    for idx in range(tlen):
+    for idx in range(consumed_count, tlen - consumed_count):
         consumed_count += 1
         if skip_ahead > 0:
             skip_ahead -= 1
@@ -37,9 +42,9 @@ def collect_module_members(parsed_tokens):
             if len(prefix_tokens) > 0:
                 return None, errors.new("Unexpected prefix tokens found before end of line.")
 
-        # else:
-        #     # Store any unrecognized tokens as prefix tokens to be processed later
-        #     prefix_tokens.append(token)
+        else:
+            # Store any unrecognized tokens as prefix tokens to be processed later
+            prefix_tokens.append(token)
 
         # Handle index advancement.
         if collect_result:

--- a/spm/internal/modulemap_parser/collect_module_members.bzl
+++ b/spm/internal/modulemap_parser/collect_module_members.bzl
@@ -1,3 +1,4 @@
+load(":collect_export_declaration.bzl", "collect_export_declaration")
 load(":collect_header_declaration.bzl", "collect_header_declaration")
 load(":collect_umbrella_dir_declaration.bzl", "collect_umbrella_dir_declaration")
 load(":collection_results.bzl", "collection_results")
@@ -82,6 +83,9 @@ def collect_module_members(parsed_tokens):
         elif tokens.is_a(token, tts.reserved, rws.header):
             collect_result, err = collect_header_declaration(parsed_tokens[idx:], prefix_tokens)
             prefix_tokens = []
+
+        elif tokens.is_a(token, tts.reserved, rws.export):
+            collect_result, err = collect_export_declaration(parsed_tokens[idx:])
 
         elif tokens.is_a(token, tts.reserved) and sets.contains(_unsupported_module_members, token.value):
             return None, errors.new("Unsupported module member token. token: %s" % (token))

--- a/spm/internal/modulemap_parser/collect_module_members.bzl
+++ b/spm/internal/modulemap_parser/collect_module_members.bzl
@@ -26,6 +26,10 @@ def collect_module_members(parsed_tokens):
     collect_result = None
     prefix_tokens = []
     for idx in range(consumed_count, tlen - consumed_count):
+        # TODO: Make sure that we are counting consumed tokens correctly. I
+        # think we may be double counting when we come back from collection
+        # functions (e.g. return collect_result).
+
         consumed_count += 1
         if skip_ahead > 0:
             skip_ahead -= 1
@@ -38,7 +42,7 @@ def collect_module_members(parsed_tokens):
 
         # Process token
 
-        if token.type == tts.curly_bracket_close:
+        if tokens.is_a(token, tts.curly_bracket_close):
             if len(prefix_tokens) > 0:
                 return None, errors.new(
                     "Unexpected prefix tokens found at end of module member block. tokens: %s" %
@@ -46,17 +50,17 @@ def collect_module_members(parsed_tokens):
                 )
             break
 
-        elif token.type == tts.newline:
+        elif tokens.is_a(token, tts.newline):
             if len(prefix_tokens) > 0:
                 return None, errors.new(
                     "Unexpected prefix tokens found before end of line. tokens: %" % (prefix_tokens),
                 )
 
-        elif token.type == tts.reserved and token.value == rws.header:
+        elif tokens.is_a(token, tts.reserved, rws.header):
             collect_result, err = collect_header_declaration(parsed_tokens[idx:], prefix_tokens)
             prefix_tokens = []
 
-        elif token.type == tts.reserved and sets.contains(_unsupported_module_members, token.value):
+        elif tokens.is_a(token, tts.reserved) and sets.contains(_unsupported_module_members, token.value):
             return None, errors.new("Unsupported module member token. token: %s" % (token))
 
         else:

--- a/spm/internal/modulemap_parser/collect_umbrella_dir_declaration.bzl
+++ b/spm/internal/modulemap_parser/collect_umbrella_dir_declaration.bzl
@@ -1,0 +1,7 @@
+load(":errors.bzl", "errors")
+load(":collection_results.bzl", "collection_results")
+load(":tokens.bzl", "tokens", rws = "reserved_words", tts = "token_types")
+load(":declarations.bzl", "declarations", dts = "declaration_types")
+
+def collect_umbrella_dir_declaration(parsed_tokens):
+    return None, errors.new("IMPLEMENT ME!")

--- a/spm/internal/modulemap_parser/collect_umbrella_dir_declaration.bzl
+++ b/spm/internal/modulemap_parser/collect_umbrella_dir_declaration.bzl
@@ -4,4 +4,33 @@ load(":tokens.bzl", "tokens", rws = "reserved_words", tts = "token_types")
 load(":declarations.bzl", "declarations", dts = "declaration_types")
 
 def collect_umbrella_dir_declaration(parsed_tokens):
-    return None, errors.new("IMPLEMENT ME!")
+    """Collect an umbrella directory declaration.
+
+    Spec: https://clang.llvm.org/docs/Modules.html#umbrella-directory-declaration
+
+    Syntax:
+        umbrella-dir-declaration:
+          umbrella string-literal
+
+    Args:
+        parsed_tokens: A `list` of tokens.
+
+    Returns:
+        A `tuple` where the first item is the collection result and the second is an
+        error `struct` as returned from errors.create().
+    """
+    tlen = len(parsed_tokens)
+    consumed_count = 0
+
+    umbrella_token, err = tokens.get_as(parsed_tokens, 0, tts.reserved, rws.umbrella, count = tlen)
+    if err != None:
+        return None, err
+    consumed_count += 1
+
+    path_token, err = tokens.get_as(parsed_tokens, 1, tts.string_literal, count = tlen)
+    if err != None:
+        return None, err
+    consumed_count += 1
+
+    decl = declarations.umbrella_directory(path_token.value)
+    return collection_results.new([decl], consumed_count), None

--- a/spm/internal/modulemap_parser/collection_results.bzl
+++ b/spm/internal/modulemap_parser/collection_results.bzl
@@ -1,0 +1,18 @@
+def _create(declarations, count):
+    """Creates a collection result `struct`.
+
+    Args:
+        declarations: The declarations that were collected.
+        count: The number of tokens that were collected.
+
+    Returns:
+        A `struct` representing the data that was collected.
+    """
+    return struct(
+        declarations = declarations,
+        count = count,
+    )
+
+collection_results = struct(
+    new = _create,
+)

--- a/spm/internal/modulemap_parser/declarations.bzl
+++ b/spm/internal/modulemap_parser/declarations.bzl
@@ -1,0 +1,45 @@
+def _create_module_decl(module_id, explicit = False, framework = False, attributes = [], members = []):
+    """Create a module declaration.
+
+    Spec: https://clang.llvm.org/docs/Modules.html#module-declaration
+
+    Args:
+        module_id: A `string` that identifies the module.
+        explicit: A `bool` that designates the module as explicit.
+        framework: A `bool` that designzates the module as being Darwin framework.
+        attributes: A `list` of `string` values specified as attrivutes.
+        members: A `list` of the module members.
+
+    Returns:
+        A `struct` representing a module declaration.
+    """
+    return struct(
+        module_id = module_id,
+        explicit = explicit,
+        framework = framework,
+        attributes = attributes,
+        members = members,
+    )
+
+def _create_extern_module_decl(module_id, definition_path):
+    """Create an extern module declaration.
+
+    Spec: https://clang.llvm.org/docs/Modules.html#module-declaration
+
+    Args:
+        module_id: A `string` that identifies the module.
+        definition_path: The path (`string`) to a file that contains the definition for the
+                         identified module.
+
+    Returns:
+        A `struct` representing an extern module declaration.
+    """
+    return struct(
+        module_id = module_id,
+        definition_path = definition_path,
+    )
+
+declarations = struct(
+    module = _create_module_decl,
+    extern_module = _create_extern_module_decl,
+)

--- a/spm/internal/modulemap_parser/declarations.bzl
+++ b/spm/internal/modulemap_parser/declarations.bzl
@@ -6,6 +6,7 @@ _declaration_types = struct(
     single_header = "single_header",
     umbrella_header = "umbrella_header",
     exclude_header = "exclude_header",
+    umbrella_directory = "umbrella_directory",
 )
 
 def _create_module_decl(module_id, explicit = False, framework = False, attributes = [], members = []):
@@ -131,6 +132,22 @@ def _create_exclude_header(path, attribs = None):
         attribs = attribs,
     )
 
+def _create_umbrella_directory(path):
+    """Creates a `struct` representing an umbrella directory declaration.
+
+    Spec: https://clang.llvm.org/docs/Modules.html#umbrella-directory-declaration
+
+    Args:
+        path: A `string` specifying the path to the directory with the header files.
+
+    Returns:
+        A `struct` representing an umbrella directory declaration.
+    """
+    return struct(
+        decl_type = _declaration_types.umbrella_directory,
+        path = path,
+    )
+
 # MARK: - Namespaces
 
 declaration_types = _declaration_types
@@ -142,4 +159,5 @@ declarations = struct(
     single_header = _create_single_header,
     umbrella_header = _create_umbrella_header,
     exclude_header = _create_exclude_header,
+    umbrella_directory = _create_umbrella_directory,
 )

--- a/spm/internal/modulemap_parser/declarations.bzl
+++ b/spm/internal/modulemap_parser/declarations.bzl
@@ -140,4 +140,6 @@ declarations = struct(
     extern_module = _create_extern_module_decl,
     header_attribs = _create_header_attributes,
     single_header = _create_single_header,
+    umbrella_header = _create_umbrella_header,
+    exclude_header = _create_exclude_header,
 )

--- a/spm/internal/modulemap_parser/declarations.bzl
+++ b/spm/internal/modulemap_parser/declarations.bzl
@@ -1,3 +1,13 @@
+# MARK: - Module Declarations
+
+_declaration_types = struct(
+    module = "module",
+    extern_module = "extern_module",
+    single_header = "single_header",
+    umbrella_header = "umbrella_header",
+    exclude_header = "exclude_header",
+)
+
 def _create_module_decl(module_id, explicit = False, framework = False, attributes = [], members = []):
     """Create a module declaration.
 
@@ -14,6 +24,7 @@ def _create_module_decl(module_id, explicit = False, framework = False, attribut
         A `struct` representing a module declaration.
     """
     return struct(
+        decl_type = _declaration_types.module,
         module_id = module_id,
         explicit = explicit,
         framework = framework,
@@ -35,11 +46,102 @@ def _create_extern_module_decl(module_id, definition_path):
         A `struct` representing an extern module declaration.
     """
     return struct(
+        decl_type = _declaration_types.extern_module,
         module_id = module_id,
         definition_path = definition_path,
     )
 
+# MARK: - Module Member Declarations
+
+# _header_decl_types = struct(
+#     single = "single",
+#     umbrella = "umbrella",
+#     exclude = "exclude",
+# )
+# _header_decl_types_dict = structs.to_dict(_header_decl_types)
+# _header_decl_types_set = sets.make([_header_decl_types_dict[k] for k in _header_decl_types_dict])
+
+# def _create_header_decl(decl_type, path, size = None, mtime = None, private = None, textual = None):
+#     """Create a header declaration.
+
+#     Spec: https://clang.llvm.org/docs/Modules.html#header-declaration
+
+#     Args:
+#         decl_type: A `string` which must be one of the `declarations.header_types` values.
+#         path: A `string` specifying the path to the header.
+#         size: An `int` specifying the size attribute value.
+#         mtime: An `int` specifying the mtime attribute value.
+#         private: For `single` type headers, this is a `bool` specifying whether it is private.
+#         textual: For `single` type headers, this is a `bool` specifying whether it is a textual header.
+
+#     Returns:
+#         A `struct` representing a header declaration.
+#     """
+#     if not sets.contains(_header_decl_types_set, decl_type):
+#         fail("Invalid header declaration type. %s" % (decl_type))
+
+#     if decl_type == _header_decl_types.single:
+#         if private == None:
+#             private = False
+#         if textual == None:
+#             textual = False
+
+#     return struct(
+#         decl_type = decl_type,
+#         path = path,
+#         size = size,
+#         mtime = mtime,
+#         private = private,
+#         textual = textual,
+#     )
+
+def _create_header_attributes(size = None, mtime = None):
+    """Creates a struct representing header attributes.
+
+    Spec: https://clang.llvm.org/docs/Modules.html#header-declaration
+
+    Args:
+        size: An `int` specifying the size attribute value.
+        mtime: An `int` specifying the mtime attribute value.
+
+    Returns:
+        A `struct` representing header attribute values.
+    """
+    return struct(
+        size = size,
+        mtime = mtime,
+    )
+
+def _create_single_header(path, private = False, textual = False, attribs = None):
+    """Creates a `struct` representing a single header declaration.
+
+    Spec: https://clang.llvm.org/docs/Modules.html#header-declaration
+
+    Args:
+        path: A `string` specifying the path to the header.
+        private: A `bool` specifying whether it is private.
+        textual: A `bool` specifying whether it is a textual header.
+        attribs: A `struct` as returned from `declarations.header_attribs()` representing the
+                 header attributes.
+
+    Returns:
+        A `struct` representing a single
+    """
+    return struct(
+        decl_type = _declaration_types.single_header,
+        path = path,
+        private = private,
+        textual = textual,
+        attribs = attribs,
+    )
+
+# MARK: - Namespaces
+
+declaration_types = _declaration_types
+
 declarations = struct(
     module = _create_module_decl,
     extern_module = _create_extern_module_decl,
+    header_attribs = _create_header_attributes,
+    single_header = _create_single_header,
 )

--- a/spm/internal/modulemap_parser/declarations.bzl
+++ b/spm/internal/modulemap_parser/declarations.bzl
@@ -7,6 +7,7 @@ _declaration_types = struct(
     umbrella_header = "umbrella_header",
     exclude_header = "exclude_header",
     umbrella_directory = "umbrella_directory",
+    export = "export",
 )
 
 def _create_module_decl(module_id, explicit = False, framework = False, attributes = [], members = []):
@@ -148,6 +149,24 @@ def _create_umbrella_directory(path):
         path = path,
     )
 
+def _create_export(identifiers = [], wildcard = False):
+    """Creates a `struct` representing an export declaration.
+
+    Spec: https://clang.llvm.org/docs/Modules.html#umbrella-directory-declaration
+
+    Args:
+        identifiers: A `list` of `string` values.
+        wildcard: A `bool` indicating whether it is a wildcard at the end of the identifiers.
+
+    Returns:
+        A `struct` representing an export declaration.
+    """
+    return struct(
+        decl_type = _declaration_types.export,
+        identifiers = identifiers,
+        wildcard = wildcard,
+    )
+
 # MARK: - Namespaces
 
 declaration_types = _declaration_types
@@ -160,4 +179,5 @@ declarations = struct(
     umbrella_header = _create_umbrella_header,
     exclude_header = _create_exclude_header,
     umbrella_directory = _create_umbrella_directory,
+    export = _create_export,
 )

--- a/spm/internal/modulemap_parser/declarations.bzl
+++ b/spm/internal/modulemap_parser/declarations.bzl
@@ -53,48 +53,6 @@ def _create_extern_module_decl(module_id, definition_path):
 
 # MARK: - Module Member Declarations
 
-# _header_decl_types = struct(
-#     single = "single",
-#     umbrella = "umbrella",
-#     exclude = "exclude",
-# )
-# _header_decl_types_dict = structs.to_dict(_header_decl_types)
-# _header_decl_types_set = sets.make([_header_decl_types_dict[k] for k in _header_decl_types_dict])
-
-# def _create_header_decl(decl_type, path, size = None, mtime = None, private = None, textual = None):
-#     """Create a header declaration.
-
-#     Spec: https://clang.llvm.org/docs/Modules.html#header-declaration
-
-#     Args:
-#         decl_type: A `string` which must be one of the `declarations.header_types` values.
-#         path: A `string` specifying the path to the header.
-#         size: An `int` specifying the size attribute value.
-#         mtime: An `int` specifying the mtime attribute value.
-#         private: For `single` type headers, this is a `bool` specifying whether it is private.
-#         textual: For `single` type headers, this is a `bool` specifying whether it is a textual header.
-
-#     Returns:
-#         A `struct` representing a header declaration.
-#     """
-#     if not sets.contains(_header_decl_types_set, decl_type):
-#         fail("Invalid header declaration type. %s" % (decl_type))
-
-#     if decl_type == _header_decl_types.single:
-#         if private == None:
-#             private = False
-#         if textual == None:
-#             textual = False
-
-#     return struct(
-#         decl_type = decl_type,
-#         path = path,
-#         size = size,
-#         mtime = mtime,
-#         private = private,
-#         textual = textual,
-#     )
-
 def _create_header_attributes(size = None, mtime = None):
     """Creates a struct representing header attributes.
 
@@ -132,6 +90,44 @@ def _create_single_header(path, private = False, textual = False, attribs = None
         path = path,
         private = private,
         textual = textual,
+        attribs = attribs,
+    )
+
+def _create_umbrella_header(path, attribs = None):
+    """Creates a `struct` representing an umbrella header declaration.
+
+    Spec: https://clang.llvm.org/docs/Modules.html#header-declaration
+
+    Args:
+        path: A `string` specifying the path to the header.
+        attribs: A `struct` as returned from `declarations.header_attribs()` representing the
+                 header attributes.
+
+    Returns:
+        A `struct` representing an umbrella header declaration.
+    """
+    return struct(
+        decl_type = _declaration_types.umbrella_header,
+        path = path,
+        attribs = attribs,
+    )
+
+def _create_exclude_header(path, attribs = None):
+    """Creates a `struct` representing an exclude header declaration.
+
+    Spec: https://clang.llvm.org/docs/Modules.html#header-declaration
+
+    Args:
+        path: A `string` specifying the path to the header.
+        attribs: A `struct` as returned from `declarations.header_attribs()` representing the
+                 header attributes.
+
+    Returns:
+        A `struct` representing an exclude header declaration.
+    """
+    return struct(
+        decl_type = _declaration_types.exclude_header,
+        path = path,
         attribs = attribs,
     )
 

--- a/spm/internal/modulemap_parser/errors.bzl
+++ b/spm/internal/modulemap_parser/errors.bzl
@@ -1,0 +1,20 @@
+def _create_error(msg, child_errors = []):
+    """Create an error `struct`.
+
+    Args:
+        msg: A `string` describing the error.
+        child_errors: A `list` of any errors that are related to this error.
+
+    Returns:
+        Returns a `struct` representing the error.
+    """
+    return struct(
+        msg = msg,
+        child_errors = child_errors,
+    )
+
+# MARK: - Namespace
+
+errors = struct(
+    new = _create_error,
+)

--- a/spm/internal/modulemap_parser/parser.bzl
+++ b/spm/internal/modulemap_parser/parser.bzl
@@ -1,0 +1,8 @@
+load(":tokenizer.bzl", "tokenize")
+
+def _parse(text):
+    tokens = tokenize(text)
+
+parser = struct(
+    parse = _parse,
+)

--- a/spm/internal/modulemap_parser/parser.bzl
+++ b/spm/internal/modulemap_parser/parser.bzl
@@ -1,13 +1,10 @@
 load(":declarations.bzl", "declarations")
 load(":errors.bzl", "errors")
 load(":tokenizer.bzl", "tokenizer")
-load(":tokens.bzl", "reserved_words", "tokens")
+load(":tokens.bzl", "tokens", rws = "reserved_words", tts = "token_types")
 load(":collection_results.bzl", "collection_results")
 load(":collect_extern_module.bzl", "collect_extern_module")
 load(":collect_module.bzl", "collect_module")
-
-tts = tokens.types
-rws = reserved_words
 
 def _parse(text):
     tokenizer_result = tokenizer.tokenize(text)
@@ -29,14 +26,14 @@ def _parse(text):
         collect_result = None
         err = None
 
-        if token.type == tokens.types.newline:
+        if token.type == tts.newline:
             pass
 
-        elif token.type == tokens.types.reserved:
-            if token.value == reserved_words.extern:
+        elif token.type == tts.reserved:
+            if token.value == rws.extern:
                 collect_result, err = collect_extern_module(parsed_tokens[idx:])
 
-            elif token.value == reserved_words.module:
+            elif token.value == rws.module:
                 collect_result, err = collect_module(
                     parsed_tokens[idx:],
                     prefix_tokens = prefix_tokens,

--- a/spm/internal/modulemap_parser/parser.bzl
+++ b/spm/internal/modulemap_parser/parser.bzl
@@ -2,24 +2,10 @@ load(":declarations.bzl", "declarations")
 load(":errors.bzl", "errors")
 load(":tokenizer.bzl", "tokenizer")
 load(":tokens.bzl", "reserved_words", "tokens")
+load(":collection_results.bzl", "collection_results")
 
 tts = tokens.types
 rws = reserved_words
-
-def _collection_result(declarations, count):
-    """Creates a collection result `struct`.
-
-    Args:
-        declarations: The declarations that were collected.
-        count: The number of tokens that were collected.
-
-    Returns:
-        A `struct` representing the data that was collected.
-    """
-    return struct(
-        declarations = declarations,
-        count = count,
-    )
 
 def _parser_result(declarations = []):
     return struct(
@@ -61,7 +47,7 @@ def _collect_extern_module(parsed_tokens):
         return None, err
 
     decl = declarations.extern_module(module_id_token.value, path_token.value)
-    return _collection_result([decl], 4), None
+    return collection_results.new([decl], 4), None
 
 def _parse(text):
     tokenizer_result = tokenizer.tokenize(text)

--- a/spm/internal/modulemap_parser/parser.bzl
+++ b/spm/internal/modulemap_parser/parser.bzl
@@ -3,51 +3,10 @@ load(":errors.bzl", "errors")
 load(":tokenizer.bzl", "tokenizer")
 load(":tokens.bzl", "reserved_words", "tokens")
 load(":collection_results.bzl", "collection_results")
+load(":collect_extern_module.bzl", "collect_extern_module")
 
 tts = tokens.types
 rws = reserved_words
-
-def _parser_result(declarations = []):
-    return struct(
-        declarations = declarations,
-    )
-
-def _collect_extern_module(parsed_tokens):
-    """Collect an extern module declaration.
-
-    Spec: https://clang.llvm.org/docs/Modules.html#module-declaration
-
-    Syntax:
-
-    extern module module-id string-literal
-
-    Args:
-        parsed_tokens: A `list` of tokens.
-
-    Returns:
-        A `tuple` where the first item is the collection result and the second is an
-        error `struct` as returned from errors.create().
-    """
-
-    tlen = len(parsed_tokens)
-    extern_token, err = tokens.get_as(parsed_tokens, 0, tts.reserved, rws.extern, count = tlen)
-    if err:
-        return None, err
-
-    module_token, err = tokens.get_as(parsed_tokens, 1, tts.reserved, rws.module, count = tlen)
-    if err:
-        return None, err
-
-    module_id_token, err = tokens.get_as(parsed_tokens, 2, tts.identifier, count = tlen)
-    if err:
-        return None, err
-
-    path_token, err = tokens.get_as(parsed_tokens, 3, tts.string_literal, count = tlen)
-    if err:
-        return None, err
-
-    decl = declarations.extern_module(module_id_token.value, path_token.value)
-    return collection_results.new([decl], 4), None
 
 def _parse(text):
     tokenizer_result = tokenizer.tokenize(text)
@@ -73,7 +32,7 @@ def _parse(text):
 
         elif token.type == tokens.types.reserved:
             if token.value == reserved_words.extern:
-                collect_result, err = _collect_extern_module(parsed_tokens[idx:])
+                collect_result, err = collect_extern_module(parsed_tokens[idx:])
                 if err:
                     return None, err
 
@@ -91,9 +50,8 @@ def _parse(text):
             collected_decls.extend(collect_result.declarations)
             skip_ahead = collect_result.count - 1
 
-    return _parser_result(collected_decls), None
+    return collected_decls, None
 
 parser = struct(
     parse = _parse,
-    result = _parser_result,
 )

--- a/spm/internal/modulemap_parser/parser.bzl
+++ b/spm/internal/modulemap_parser/parser.bzl
@@ -4,6 +4,7 @@ load(":tokenizer.bzl", "tokenizer")
 load(":tokens.bzl", "reserved_words", "tokens")
 load(":collection_results.bzl", "collection_results")
 load(":collect_extern_module.bzl", "collect_extern_module")
+load(":collect_module.bzl", "collect_module")
 
 tts = tokens.types
 rws = reserved_words
@@ -26,6 +27,7 @@ def _parse(text):
 
         token = parsed_tokens[idx]
         collect_result = None
+        err = None
 
         if token.type == tokens.types.newline:
             pass
@@ -33,18 +35,22 @@ def _parse(text):
         elif token.type == tokens.types.reserved:
             if token.value == reserved_words.extern:
                 collect_result, err = collect_extern_module(parsed_tokens[idx:])
-                if err:
-                    return None, err
 
             elif token.value == reserved_words.module:
-                # TODO: IMPLEMENT ME!
-                pass
+                collect_result, err = collect_module(
+                    parsed_tokens[idx:],
+                    prefix_tokens = prefix_tokens,
+                )
+                prefix_tokens = []
 
             else:
                 prefix_tokens.append(token)
 
         else:
             prefix_tokens.append(token)
+
+        if err:
+            return None, err
 
         if collect_result:
             collected_decls.extend(collect_result.declarations)

--- a/spm/internal/modulemap_parser/parser.bzl
+++ b/spm/internal/modulemap_parser/parser.bzl
@@ -1,8 +1,38 @@
-load(":tokenizer.bzl", "tokenize")
+load(":tokenizer.bzl", "tokenizer")
+load(":tokens.bzl", "tokens")
+
+def _parser_result(declarations = [], errors = []):
+    return struct(
+        declarations = declarations,
+        errors = errors,
+    )
 
 def _parse(text):
-    tokens = tokenize(text)
+    tokenizer_result = tokenizer.tokenize(text)
+    if len(tokenizer_result.errors) > 0:
+        return _parser_result(errors = tokenizer_result.errors)
+
+    parsed_tokens = tokenizer_result.tokens
+    tokens_cnt = len(parsed_tokens)
+
+    collected_decls = []
+    skip_ahead = 0
+    prefix_tokens = []
+    for idx in range(tokens_cnt):
+        if skip_ahead > 0:
+            skip_ahead -= 1
+            continue
+
+        token = parsed_tokens[idx]
+
+        if token.type == tokens.types.newline:
+            pass
+        else:
+            prefix_tokens.append(token)
+
+    return _parser_result(collected_decls)
 
 parser = struct(
     parse = _parse,
+    result = _parser_result,
 )

--- a/spm/internal/modulemap_parser/parser.bzl
+++ b/spm/internal/modulemap_parser/parser.bzl
@@ -1,11 +1,43 @@
 load(":tokenizer.bzl", "tokenizer")
-load(":tokens.bzl", "tokens")
+load(":tokens.bzl", "reserved_words", "tokens")
+
+def _collection_result(declarations, count, errors = []):
+    """Creates a collection result `struct`.
+
+    Args:
+        declarations: The declarations that were collected.
+        count: The number of tokens that were collected.
+        errors: A `list` of errors that were found.
+
+    Returns:
+        A `struct` representing the data that was collected.
+    """
+    return struct(
+        declarations = declarations,
+        count = count,
+        errors = errors,
+    )
 
 def _parser_result(declarations = [], errors = []):
     return struct(
         declarations = declarations,
         errors = errors,
     )
+
+def _collect_extern_module(parsed_tokens):
+    """Collect an extern module declaration.
+
+    Syntax
+
+    extern module module-id string-literal
+
+    Args:
+        parsed_tokens: A `list` of tokens.
+
+    Returns:
+        A collection result `struct`.
+    """
+    return _collection_result([], 0)
 
 def _parse(text):
     tokenizer_result = tokenizer.tokenize(text)
@@ -24,11 +56,28 @@ def _parse(text):
             continue
 
         token = parsed_tokens[idx]
+        collect_result = None
 
         if token.type == tokens.types.newline:
             pass
+
+        elif token.type == tokens.types.reserved:
+            if token.value == reserved_words.extern:
+                collect_result = _collect_extern_module(parsed_tokens[idx:])
+
+            elif token.value == reserved_words.module:
+                # TODO: IMPLEMENT ME!
+                pass
+
+            else:
+                prefix_tokens.append(token)
+
         else:
             prefix_tokens.append(token)
+
+        if collect_result:
+            collected_decls.extend(collect_result.declarations)
+            skip_ahead = collect_result.count - 1
 
     return _parser_result(collected_decls)
 

--- a/spm/internal/modulemap_parser/parser.bzl
+++ b/spm/internal/modulemap_parser/parser.bzl
@@ -1,5 +1,6 @@
 load(":tokenizer.bzl", "tokenizer")
 load(":tokens.bzl", "reserved_words", "tokens")
+load(":errors.bzl", "errors")
 
 def _collection_result(declarations, count):
     """Creates a collection result `struct`.
@@ -21,12 +22,6 @@ def _parser_result(declarations = []):
         declarations = declarations,
     )
 
-def _error(msg, child_errors = []):
-    return struct(
-        msg = msg,
-        child_errors = child_errors,
-    )
-
 def _collect_extern_module(parsed_tokens):
     """Collect an extern module declaration.
 
@@ -41,18 +36,18 @@ def _collect_extern_module(parsed_tokens):
 
     Returns:
         A `tuple` where the first item is the collection result and the second is an
-        error `struct` as returned from _error().
+        error `struct` as returned from errors.create().
     """
     extern_token, err = tokens.next(parsed_tokens, 0)
     if err:
-        return None, _error("Failed to find extern token.")
+        return None, errors.new("Failed to find extern token.")
 
-    return _collection_result([], 0)
+    return _collection_result([], 0), None
 
 def _parse(text):
     tokenizer_result = tokenizer.tokenize(text)
     if len(tokenizer_result.errors) > 0:
-        return None, _error("Errors from tokenizer", tokenizer_result.errors)
+        return None, errors.new("Errors from tokenizer", tokenizer_result.errors)
 
     parsed_tokens = tokenizer_result.tokens
     tokens_cnt = len(parsed_tokens)

--- a/spm/internal/modulemap_parser/parser.bzl
+++ b/spm/internal/modulemap_parser/parser.bzl
@@ -43,26 +43,20 @@ def _collect_extern_module(parsed_tokens):
         error `struct` as returned from errors.create().
     """
 
-    # DEBUG BEGIN
-    print("*** CHUCK parsed_tokens: ")
-    for idx, item in enumerate(parsed_tokens):
-        print("*** CHUCK", idx, ":", item)
-
-    # DEBUG END
     tlen = len(parsed_tokens)
-    extern_token, err = tokens.next_as(parsed_tokens, 0, tts.reserved, rws.extern, count = tlen)
+    extern_token, err = tokens.get_as(parsed_tokens, 0, tts.reserved, rws.extern, count = tlen)
     if err:
         return None, err
 
-    module_token, err = tokens.next_as(parsed_tokens, 1, tts.reserved, rws.module, count = tlen)
+    module_token, err = tokens.get_as(parsed_tokens, 1, tts.reserved, rws.module, count = tlen)
     if err:
         return None, err
 
-    module_id_token, err = tokens.next_as(parsed_tokens, 2, tts.identifier, count = tlen)
+    module_id_token, err = tokens.get_as(parsed_tokens, 2, tts.identifier, count = tlen)
     if err:
         return None, err
 
-    path_token, err = tokens.next_as(parsed_tokens, 3, tts.string_literal, count = tlen)
+    path_token, err = tokens.get_as(parsed_tokens, 3, tts.string_literal, count = tlen)
     if err:
         return None, err
 
@@ -108,10 +102,6 @@ def _parse(text):
             prefix_tokens.append(token)
 
         if collect_result:
-            # DEBUG BEGIN
-            print("*** CHUCK collect_result: ", collect_result)
-
-            # DEBUG END
             collected_decls.extend(collect_result.declarations)
             skip_ahead = collect_result.count - 1
 

--- a/spm/internal/modulemap_parser/parser.bzl
+++ b/spm/internal/modulemap_parser/parser.bzl
@@ -45,8 +45,8 @@ def _collect_extern_module(parsed_tokens):
 
     # DEBUG BEGIN
     print("*** CHUCK parsed_tokens: ")
-    for t in parsed_tokens:
-        print("*** CHUCK t: ", t)
+    for idx, item in enumerate(parsed_tokens):
+        print("*** CHUCK", idx, ":", item)
 
     # DEBUG END
     tlen = len(parsed_tokens)

--- a/spm/internal/modulemap_parser/tokenizer.bzl
+++ b/spm/internal/modulemap_parser/tokenizer.bzl
@@ -13,9 +13,10 @@ _newlines = sets.make([
     "\\f",  # form feed
 ])
 
-def _tokenizer_result(tokens, errors = []):
+def _tokenizer_result(tokens, consumed_count = 0, errors = []):
     return struct(
         tokens = tokens,
+        consumed_count = consumed_count,
         errors = errors,
     )
 
@@ -23,6 +24,19 @@ def _error(char, msg):
     return struct(
         char = char,
         msg = msg,
+    )
+
+def _collect_newlines(chars):
+    count = 0
+    for char in chars:
+        if sets.contains(_newlines, char):
+            count += 1
+        else:
+            break
+
+    return _tokenizer_result(
+        tokens = [tokens.newLine()],
+        consumed_count = count,
     )
 
 def _tokenize(text):
@@ -41,38 +55,40 @@ def _tokenize(text):
     idx = 0
     charsLen = len(chars)
 
+    skip_ahead = 0
     for idx in range(charsLen):
+        if skip_ahead > 0:
+            skip_ahead -= 1
+            continue
+
         char = chars[idx]
         if sets.contains(_whitespaces, char):
-            idx += 1
+            pass
+        elif sets.contains(_newlines, char):
+            nl_result = _collect_newlines()
+            collected_tokens.extend(nl_result.tokens)
+            skip_ahead = nl_result.consumed_count
         elif char == "{":
             collected_tokens.append(tokens.curly_bracket_open())
-            idx += 1
         elif char == "}":
             collected_tokens.append(tokens.curly_bracket_close())
-            idx += 1
         elif char == "[":
             collected_tokens.append(tokens.square_bracket_open())
-            idx += 1
         elif char == "]":
             collected_tokens.append(tokens.square_bracket_close())
-            idx += 1
         elif char == "!":
             collected_tokens.append(tokens.exclamation_point())
-            idx += 1
         elif char == ",":
             collected_tokens.append(tokens.comma())
-            idx += 1
         elif char == ".":
             collected_tokens.append(tokens.period())
-            idx += 1
         else:
             # Did not recognize the char. Keep trucking.
             err = _error(char, "Unrecognized character")
             errors.append(err)
             idx += 1
 
-    return _tokenizer_result(collected_tokens, errors)
+    return _tokenizer_result(collected_tokens, consumed_count = charsLen, errors = errors)
 
 tokenizer = struct(
     tokenize = _tokenize,

--- a/spm/internal/modulemap_parser/tokenizer.bzl
+++ b/spm/internal/modulemap_parser/tokenizer.bzl
@@ -72,7 +72,6 @@ def _tokenize(text):
     errors = []
 
     chars = text.elems()
-    idx = 0
     chars_len = len(chars)
 
     skip_ahead = 0

--- a/spm/internal/modulemap_parser/tokenizer.bzl
+++ b/spm/internal/modulemap_parser/tokenizer.bzl
@@ -1,17 +1,6 @@
-load("//spm/internal/modulemap_parser:tokens.bzl", "tokens")
+load(":tokens.bzl", "tokens")
+load(":character_sets.bzl", "character_sets")
 load("@bazel_skylib//lib:sets.bzl", "sets")
-
-_whitespaces = sets.make([
-    " ",  # space
-    "\t",  # horizontal tab
-    # "\\v",  # vertical tab
-    # "\\b",  # backspace
-])
-_newlines = sets.make([
-    "\n",  # line feed
-    "\r",  # carriage return
-    # "\\f",  # form feed
-])
 
 def _tokenizer_result(tokens, errors = []):
     return struct(
@@ -39,29 +28,6 @@ def _error(char, msg):
         char = char,
         msg = msg,
     )
-
-# def _slice_after(target_list, current_idx, list_len = None):
-#     if not list_len:
-#         list_len = len(target_list)
-#     # If the next index is past the end, return an empty list
-#     # Else slice from  the next index.
-#     next_idx = current_idx + 1
-#     if next_idx >= list_len:
-#         return []
-#     return target_list[next_idx:]
-
-# def _collect_newlines(chars):
-#     count = 0
-#     for char in chars:
-#         if sets.contains(_newlines, char):
-#             count += 1
-#         else:
-#             break
-
-#     return _tokenizer_result(
-#         tokens = [tokens.newLine()],
-#         consumed_count = count,
-#     )
 
 def _collect_chars_in_set(chars, target_set):
     collected_chars = []
@@ -113,15 +79,15 @@ def _tokenize(text):
             collected_tokens.append(tokens.comma())
         elif char == ".":
             collected_tokens.append(tokens.period())
-        elif sets.contains(_whitespaces, char):
+        elif sets.contains(character_sets.whitespaces, char):
             pass
-        elif sets.contains(_newlines, char):
-            collect_result = _collect_chars_in_set(chars[idx:], _newlines)
+        elif sets.contains(character_sets.newlines, char):
+            collect_result = _collect_chars_in_set(chars[idx:], character_sets.newlines)
             collected_tokens.append(tokens.newline())
         elif sets.contains(tokens.operators, char):
             # If we implement more than just asterisk for operators, this will need to be
             # revisited.
-            collect_result = _collect_chars_in_set(chars[idx:], tokens.operators)
+            collect_result = _collect_chars_in_set(chars[idx:], character_sets.operators)
             collected_tokens.append(tokens.operator(collect_result.chars))
         else:
             # Did not recognize the char. Keep trucking.

--- a/spm/internal/modulemap_parser/tokenizer.bzl
+++ b/spm/internal/modulemap_parser/tokenizer.bzl
@@ -116,7 +116,7 @@ def _tokenize(text):
             else:
                 id_token = tokens.identifier(collect_result.value)
             collected_tokens.append(id_token)
-        elif sets.contains(tokens.operators, char):
+        elif sets.contains(tokens.c99_operators, char):
             # If we implement more than just asterisk for operators, this will need to be
             # revisited.
             collect_result = _collect_chars_in_set(chars[idx:], character_sets.operators)

--- a/spm/internal/modulemap_parser/tokenizer.bzl
+++ b/spm/internal/modulemap_parser/tokenizer.bzl
@@ -84,6 +84,17 @@ def _tokenize(text):
         elif sets.contains(character_sets.newlines, char):
             collect_result = _collect_chars_in_set(chars[idx:], character_sets.newlines)
             collected_tokens.append(tokens.newline())
+        elif sets.contains(character_sets.c99_identifier_beginning_characters, char):
+            collect_result = _collect_chars_in_set(
+                chars[idx:],
+                character_sets.c99_identifier_characters,
+            )
+            collected_value = "".join(collect_result.chars)
+            if sets.contains(tokens.reserved_words, collected_value):
+                id_token = tokens.reserved(collected_value)
+            else:
+                id_token = tokens.identifier(collected_value)
+            collected_tokens.append(id_token)
         elif sets.contains(tokens.operators, char):
             # If we implement more than just asterisk for operators, this will need to be
             # revisited.

--- a/spm/internal/modulemap_parser/tokenizer.bzl
+++ b/spm/internal/modulemap_parser/tokenizer.bzl
@@ -26,6 +26,17 @@ def _error(char, msg):
         msg = msg,
     )
 
+def _slice_after(target_list, current_idx, list_len = None):
+    if not list_len:
+        list_len = len(target_list)
+
+    # If the next index is past the end, return an empty list
+    # Else slice from  the next index.
+    next_idx = current_idx + 1
+    if next_idx >= list_len:
+        return []
+    return target_list[next_idx:]
+
 def _collect_newlines(chars):
     count = 0
     for char in chars:
@@ -33,6 +44,11 @@ def _collect_newlines(chars):
             count += 1
         else:
             break
+
+    # DEBUG BEGIN
+    print("*** CHUCK chars: ", chars)
+    print("*** CHUCK _collect_newlines count: ", count)
+    # DEBUG END
 
     return _tokenizer_result(
         tokens = [tokens.newLine()],
@@ -65,7 +81,7 @@ def _tokenize(text):
         if sets.contains(_whitespaces, char):
             pass
         elif sets.contains(_newlines, char):
-            nl_result = _collect_newlines()
+            nl_result = _collect_newlines(_slice_after(chars, idx, list_len = charsLen))
             collected_tokens.extend(nl_result.tokens)
             skip_ahead = nl_result.consumed_count
         elif char == "{":

--- a/spm/internal/modulemap_parser/tokenizer.bzl
+++ b/spm/internal/modulemap_parser/tokenizer.bzl
@@ -1,0 +1,16 @@
+load("//spm/internal/modulemap_parser:tokens.bzl", "tokens")
+
+def _tokenize(text):
+    """Collects the tokens from the specified text.
+
+    Args:
+        text: A `string` from which the tokens are derived.
+
+    Returns:
+        A `list` of tokens.
+    """
+    pass
+
+tokenizer = struct(
+    tokenize = _tokenize,
+)

--- a/spm/internal/modulemap_parser/tokenizer.bzl
+++ b/spm/internal/modulemap_parser/tokenizer.bzl
@@ -78,13 +78,7 @@ def _tokenize(text):
             continue
 
         char = chars[idx]
-        if sets.contains(_whitespaces, char):
-            pass
-        elif sets.contains(_newlines, char):
-            nl_result = _collect_newlines(_slice_after(chars, idx, list_len = charsLen))
-            collected_tokens.extend(nl_result.tokens)
-            skip_ahead = nl_result.consumed_count
-        elif char == "{":
+        if char == "{":
             collected_tokens.append(tokens.curly_bracket_open())
         elif char == "}":
             collected_tokens.append(tokens.curly_bracket_close())
@@ -98,6 +92,12 @@ def _tokenize(text):
             collected_tokens.append(tokens.comma())
         elif char == ".":
             collected_tokens.append(tokens.period())
+        elif sets.contains(_whitespaces, char):
+            pass
+        elif sets.contains(_newlines, char):
+            nl_result = _collect_newlines(_slice_after(chars, idx, list_len = charsLen))
+            collected_tokens.extend(nl_result.tokens)
+            skip_ahead = nl_result.consumed_count
         else:
             # Did not recognize the char. Keep trucking.
             err = _error(char, "Unrecognized character")

--- a/spm/internal/modulemap_parser/tokenizer.bzl
+++ b/spm/internal/modulemap_parser/tokenizer.bzl
@@ -1,4 +1,4 @@
-load(":tokens.bzl", "tokens")
+load(":tokens.bzl", "reserved_words_set", "tokens")
 load(":character_sets.bzl", "character_sets")
 load("@bazel_skylib//lib:sets.bzl", "sets")
 
@@ -120,7 +120,7 @@ def _tokenize(text):
                 chars[idx:],
                 character_sets.c99_identifier_characters,
             )
-            if sets.contains(tokens.reserved_words, collect_result.value):
+            if sets.contains(reserved_words_set, collect_result.value):
                 id_token = tokens.reserved(collect_result.value)
             else:
                 id_token = tokens.identifier(collect_result.value)

--- a/spm/internal/modulemap_parser/tokenizer.bzl
+++ b/spm/internal/modulemap_parser/tokenizer.bzl
@@ -141,11 +141,11 @@ def _tokenize(text):
                 num_token = tokens.integer_literal(int(num_str))
             collected_tokens.append(num_token)
 
-        elif sets.contains(tokens.c99_operators, char):
+        elif sets.contains(character_sets.c99_operators, char):
             # If we implement more than just asterisk for operators, this will need to be
             # revisited.
-            collect_result = _collect_chars_in_set(chars[idx:], character_sets.operators)
-            collected_tokens.append(tokens.operator(collect_result.chars))
+            collect_result = _collect_chars_in_set(chars[idx:], character_sets.c99_operators)
+            collected_tokens.append(tokens.operator("".join(collect_result.chars)))
 
         else:
             # Did not recognize the char. Keep trucking.

--- a/spm/internal/modulemap_parser/tokenizer.bzl
+++ b/spm/internal/modulemap_parser/tokenizer.bzl
@@ -1,4 +1,29 @@
 load("//spm/internal/modulemap_parser:tokens.bzl", "tokens")
+load("@bazel_skylib//lib:sets.bzl", "sets")
+
+_whitespaces = sets.make([
+    " ",  # space
+    "\t",  # horizontal tab
+    "\\v",  # vertical tab
+    "\\b",  # backspace
+])
+_newlines = sets.make([
+    "\n",  # line feed
+    "\r",  # carriage return
+    "\\f",  # form feed
+])
+
+def _tokenizer_result(tokens, errors = []):
+    return struct(
+        tokens = tokens,
+        errors = errors,
+    )
+
+def _error(char, msg):
+    return struct(
+        char = char,
+        msg = msg,
+    )
 
 def _tokenize(text):
     """Collects the tokens from the specified text.
@@ -9,8 +34,26 @@ def _tokenize(text):
     Returns:
         A `list` of tokens.
     """
-    pass
+    tokens = []
+    errors = []
+
+    chars = text.elems()
+    idx = 0
+    charsLen = len(chars)
+
+    # while idx < charsLen:
+    # char = chars[idx]
+    # if sets.contains(_whitespaces, char):
+    #     idx += 1
+    # else:
+    #     # Did not recognize the char. Keep trucking.
+    #     # err = _error(char, "Unrecognized character")
+    #     # errors.append(err)
+    #     idx += 1
+
+    return _tokenizer_result(tokens, errors)
 
 tokenizer = struct(
     tokenize = _tokenize,
+    result = _tokenizer_result,
 )

--- a/spm/internal/modulemap_parser/tokenizer.bzl
+++ b/spm/internal/modulemap_parser/tokenizer.bzl
@@ -56,7 +56,7 @@ def _collect_string_literal(chars):
 
     return _collection_result(
         chars = collected_chars,
-        count = len(collected_chars) + 2,  # Need account for string delimiters.
+        count = len(collected_chars) + 2,  # Need to account for string delimiters.
     )
 
 def _tokenize(text):

--- a/spm/internal/modulemap_parser/tokenizer.bzl
+++ b/spm/internal/modulemap_parser/tokenizer.bzl
@@ -99,8 +99,8 @@ def _tokenize(text):
             collected_tokens.append(tokens.period())
         elif char == "\"":
             collect_result = _collect_string_literal(chars[idx:])
-            collected_value = "".join(collect_result.chars)
-            collected_tokens.append(tokens.string_literal(collected_value))
+
+            collected_tokens.append(tokens.string_literal(collect_result.value))
         elif sets.contains(character_sets.whitespaces, char):
             pass
         elif sets.contains(character_sets.newlines, char):
@@ -111,11 +111,10 @@ def _tokenize(text):
                 chars[idx:],
                 character_sets.c99_identifier_characters,
             )
-            collected_value = "".join(collect_result.chars)
-            if sets.contains(tokens.reserved_words, collected_value):
-                id_token = tokens.reserved(collected_value)
+            if sets.contains(tokens.reserved_words, collect_result.value):
+                id_token = tokens.reserved(collect_result.value)
             else:
-                id_token = tokens.identifier(collected_value)
+                id_token = tokens.identifier(collect_result.value)
             collected_tokens.append(id_token)
         elif sets.contains(tokens.operators, char):
             # If we implement more than just asterisk for operators, this will need to be
@@ -129,7 +128,7 @@ def _tokenize(text):
             idx += 1
 
         if collect_result:
-            skip_ahead = len(collect_result.chars) - 1
+            skip_ahead = collect_result.count - 1
 
     return _tokenizer_result(collected_tokens, errors = errors)
 

--- a/spm/internal/modulemap_parser/tokenizer.bzl
+++ b/spm/internal/modulemap_parser/tokenizer.bzl
@@ -34,24 +34,45 @@ def _tokenize(text):
     Returns:
         A `list` of tokens.
     """
-    tokens = []
+    collected_tokens = []
     errors = []
 
     chars = text.elems()
     idx = 0
     charsLen = len(chars)
 
-    # while idx < charsLen:
-    # char = chars[idx]
-    # if sets.contains(_whitespaces, char):
-    #     idx += 1
-    # else:
-    #     # Did not recognize the char. Keep trucking.
-    #     # err = _error(char, "Unrecognized character")
-    #     # errors.append(err)
-    #     idx += 1
+    for idx in range(charsLen):
+        char = chars[idx]
+        if sets.contains(_whitespaces, char):
+            idx += 1
+        elif char == "{":
+            collected_tokens.append(tokens.curly_bracket_open())
+            idx += 1
+        elif char == "}":
+            collected_tokens.append(tokens.curly_bracket_close())
+            idx += 1
+        elif char == "[":
+            collected_tokens.append(tokens.square_bracket_open())
+            idx += 1
+        elif char == "]":
+            collected_tokens.append(tokens.square_bracket_close())
+            idx += 1
+        elif char == "!":
+            collected_tokens.append(tokens.exclamation_point())
+            idx += 1
+        elif char == ",":
+            collected_tokens.append(tokens.comma())
+            idx += 1
+        elif char == ".":
+            collected_tokens.append(tokens.period())
+            idx += 1
+        else:
+            # Did not recognize the char. Keep trucking.
+            err = _error(char, "Unrecognized character")
+            errors.append(err)
+            idx += 1
 
-    return _tokenizer_result(tokens, errors)
+    return _tokenizer_result(collected_tokens, errors)
 
 tokenizer = struct(
     tokenize = _tokenize,

--- a/spm/internal/modulemap_parser/tokenizer.bzl
+++ b/spm/internal/modulemap_parser/tokenizer.bzl
@@ -73,10 +73,10 @@ def _tokenize(text):
 
     chars = text.elems()
     idx = 0
-    charsLen = len(chars)
+    chars_len = len(chars)
 
     skip_ahead = 0
-    for idx in range(charsLen):
+    for idx in range(chars_len):
         if skip_ahead > 0:
             skip_ahead -= 1
             continue

--- a/spm/internal/modulemap_parser/tokens.bzl
+++ b/spm/internal/modulemap_parser/tokens.bzl
@@ -85,6 +85,9 @@ RESERVED_WORDS = sets.make(_reserved_words)
 
 # MARK: - Operators
 
+# NOTE: This is meant to be a set of the operators not a set of the operator characters.
+# For instance, operator characters could be ["*", "=", "+"] while the list of operators
+# could be ["*", "+", "+=", "="].
 OPERATORS = sets.make(["*"])
 
 # MARK: - Token Types
@@ -162,7 +165,6 @@ tokens = struct(
 
     # Specialty sets
     reserved_words = RESERVED_WORDS,
-    operators = OPERATORS,
 
     # Token Factories
     reserved = _create_reserved,

--- a/spm/internal/modulemap_parser/tokens.bzl
+++ b/spm/internal/modulemap_parser/tokens.bzl
@@ -3,6 +3,8 @@ load("@bazel_skylib//lib:sets.bzl", "sets")
 load("@bazel_skylib//lib:structs.bzl", "structs")
 load("@bazel_skylib//lib:types.bzl", "types")
 
+# MARK: - Token Creation Functions
+
 def _is_valid_value(value_type_or_set, value):
     """Returns a boolean indicating whether the specified value is valid for the specified value 
     type.
@@ -36,47 +38,6 @@ def _create_token_type(name, value_type_or_set = type(None)):
         is_valid_value_fn = partial.make(_is_valid_value, value_type_or_set),
     )
 
-RESERVED_WORDS = sets.make([
-    "config_macros",
-    "conflict",
-    "exclude",
-    "explicit",
-    "export",
-    "export_as",
-    "extern",
-    "framework",
-    "header",
-    "link",
-    "module",
-    "private",
-    "requires",
-    "textual",
-    "umbrella",
-    "use",
-])
-
-OPERATORS = sets.make(["*"])
-
-_token_types = struct(
-    reserved = _create_token_type("reserved", RESERVED_WORDS),
-    identifier = _create_token_type("identifier", "string"),
-    string_literal = _create_token_type("string_literal", "string"),
-    integer_literal = _create_token_type("integer_literal", "int"),
-    float_literal = _create_token_type("float_literal", "float"),
-    comment = _create_token_type("comment", "string"),
-    operator = _create_token_type("operator", OPERATORS),
-    curly_bracket_open = _create_token_type("curly_bracket_open"),
-    curly_bracket_close = _create_token_type("curly_bracket_close"),
-    newLine = _create_token_type("newLine"),
-    square_bracket_open = _create_token_type("square_bracket_open"),
-    square_bracket_close = _create_token_type("square_bracket_close"),
-    exclamation_point = _create_token_type("exclamation_point"),
-    comma = _create_token_type("comma"),
-    period = _create_token_type("period"),
-)
-
-_token_types_dict = structs.to_dict(_token_types)
-
 def _create(token_type_or_name, value = None):
     """Create a token of the specified type.
 
@@ -99,6 +60,54 @@ def _create(token_type_or_name, value = None):
         type = token_type,
         value = value,
     )
+
+# MARK: - Reserved Words
+
+_reserved_words = [
+    "config_macros",
+    "conflict",
+    "exclude",
+    "explicit",
+    "export",
+    "export_as",
+    "extern",
+    "framework",
+    "header",
+    "link",
+    "module",
+    "private",
+    "requires",
+    "textual",
+    "umbrella",
+    "use",
+]
+RESERVED_WORDS = sets.make(_reserved_words)
+
+# MARK: - Operators
+
+OPERATORS = sets.make(["*"])
+
+# MARK: - Token Types
+
+_token_types = struct(
+    reserved = _create_token_type("reserved", RESERVED_WORDS),
+    identifier = _create_token_type("identifier", "string"),
+    string_literal = _create_token_type("string_literal", "string"),
+    integer_literal = _create_token_type("integer_literal", "int"),
+    float_literal = _create_token_type("float_literal", "float"),
+    comment = _create_token_type("comment", "string"),
+    operator = _create_token_type("operator", OPERATORS),
+    curly_bracket_open = _create_token_type("curly_bracket_open"),
+    curly_bracket_close = _create_token_type("curly_bracket_close"),
+    newLine = _create_token_type("newLine"),
+    square_bracket_open = _create_token_type("square_bracket_open"),
+    square_bracket_close = _create_token_type("square_bracket_close"),
+    exclamation_point = _create_token_type("exclamation_point"),
+    comma = _create_token_type("comma"),
+    period = _create_token_type("period"),
+)
+
+_token_types_dict = structs.to_dict(_token_types)
 
 def _create_reserved(value):
     return _create(_token_types.reserved, value)
@@ -145,8 +154,17 @@ def _create_comma():
 def _create_period():
     return _create(_token_types.period)
 
+# MARK: - Tokens Namespace
+
 tokens = struct(
+    # Token Types
     types = _token_types,
+
+    # Specialty sets
+    reserved_words = RESERVED_WORDS,
+    operators = OPERATORS,
+
+    # Token Factories
     reserved = _create_reserved,
     identifier = _create_identifier,
     string_literal = _create_string_literal,

--- a/spm/internal/modulemap_parser/tokens.bzl
+++ b/spm/internal/modulemap_parser/tokens.bzl
@@ -162,8 +162,8 @@ def _create_period():
 
 # MARK: - Token List Functions
 
-def _next_token(tokens, idx, count = None):
-    """Returns the next token in the list.
+def _get_token(tokens, idx, count = None):
+    """Returns the token in the list at the specified index.
 
     Args:
         tokens: A `list` of tokens.
@@ -171,17 +171,18 @@ def _next_token(tokens, idx, count = None):
         count: Optional. The number of tokens in the list.
 
     Returns:
-        A `tuple` where the first item is the next token and the second item is an error, if any
+        A `tuple` where the first item is the token and the second item is an error, if any
         occurred.
     """
-    if not count:
+    if count == None:
         count = len(tokens)
-    next_idx = idx + 1
-    if next_idx >= count:
-        return None, errors.new("No more tokens available.")
-    return tokens[next_idx], None
+    if idx < 0:
+        return None, errors.new("Negative indices are not supported. idx: %s" % (idx))
+    if idx >= count:
+        return None, errors.new("No more tokens available. count: %s, idx: %s" % (count, idx))
+    return tokens[idx], None
 
-def _next_token_as(tokens, idx, expected_type, expected_value = None, count = None):
+def _get_token_as(tokens, idx, expected_type, expected_value = None, count = None):
     """Returns the next token in the list if it matches the specified type and, optionally, the
     specified value.
 
@@ -196,7 +197,7 @@ def _next_token_as(tokens, idx, expected_type, expected_value = None, count = No
         A `tuple` where the first item is the next token and the second item is an error, if any
         occurred.
     """
-    token, err = _next_token(tokens, idx, count = count)
+    token, err = _get_token(tokens, idx, count = count)
     if err:
         return None, err
     if token.type != expected_type:
@@ -232,8 +233,8 @@ tokens = struct(
     period = _create_period,
 
     # Token List Functions
-    next = _next_token,
-    next_as = _next_token_as,
+    get = _get_token,
+    get_as = _get_token_as,
 )
 
 reserved_words = _reserved_words

--- a/spm/internal/modulemap_parser/tokens.bzl
+++ b/spm/internal/modulemap_parser/tokens.bzl
@@ -99,7 +99,7 @@ _token_types = struct(
     operator = _create_token_type("operator", OPERATORS),
     curly_bracket_open = _create_token_type("curly_bracket_open"),
     curly_bracket_close = _create_token_type("curly_bracket_close"),
-    newLine = _create_token_type("newLine"),
+    newline = _create_token_type("newline"),
     square_bracket_open = _create_token_type("square_bracket_open"),
     square_bracket_close = _create_token_type("square_bracket_close"),
     exclamation_point = _create_token_type("exclamation_point"),
@@ -136,8 +136,8 @@ def _create_curly_bracket_open():
 def _create_curly_bracket_close():
     return _create(_token_types.curly_bracket_close)
 
-def _create_newLine():
-    return _create(_token_types.newLine)
+def _create_newline():
+    return _create(_token_types.newline)
 
 def _create_square_bracket_open():
     return _create(_token_types.square_bracket_open)
@@ -174,7 +174,7 @@ tokens = struct(
     operator = _create_operator,
     curly_bracket_open = _create_curly_bracket_open,
     curly_bracket_close = _create_curly_bracket_close,
-    newLine = _create_newLine,
+    newline = _create_newline,
     square_bracket_open = _create_square_bracket_open,
     square_bracket_close = _create_square_bracket_close,
     exclamation_point = _create_exclamation_point,

--- a/spm/internal/modulemap_parser/tokens.bzl
+++ b/spm/internal/modulemap_parser/tokens.bzl
@@ -63,25 +63,46 @@ def _create(token_type_or_name, value = None):
 
 # MARK: - Reserved Words
 
-_reserved_words = [
-    "config_macros",
-    "conflict",
-    "exclude",
-    "explicit",
-    "export",
-    "export_as",
-    "extern",
-    "framework",
-    "header",
-    "link",
-    "module",
-    "private",
-    "requires",
-    "textual",
-    "umbrella",
-    "use",
-]
-RESERVED_WORDS = sets.make(_reserved_words)
+# _reserved_words = [
+#     "config_macros",
+#     "conflict",
+#     "exclude",
+#     "explicit",
+#     "export",
+#     "export_as",
+#     "extern",
+#     "framework",
+#     "header",
+#     "link",
+#     "module",
+#     "private",
+#     "requires",
+#     "textual",
+#     "umbrella",
+#     "use",
+# ]
+# RESERVED_WORDS = sets.make(_reserved_words)
+
+_reserved_words = struct(
+    config_macros = "config_macros",
+    conflict = "conflict",
+    exclude = "exclude",
+    explicit = "explicit",
+    export = "export",
+    export_as = "export_as",
+    extern = "extern",
+    framework = "framework",
+    header = "header",
+    link = "link",
+    module = "module",
+    private = "private",
+    requires = "requires",
+    textual = "textual",
+    umbrella = "umbrella",
+    use = "use",
+)
+_reserved_words_dict = structs.to_dict(_reserved_words)
+RESERVED_WORDS = sets.make([_reserved_words_dict[k] for k in _reserved_words_dict])
 
 # MARK: - Operators
 
@@ -183,3 +204,5 @@ tokens = struct(
     comma = _create_comma,
     period = _create_period,
 )
+
+reserved_words = _reserved_words

--- a/spm/internal/modulemap_parser/tokens.bzl
+++ b/spm/internal/modulemap_parser/tokens.bzl
@@ -158,6 +158,25 @@ def _create_comma():
 def _create_period():
     return _create(_token_types.period)
 
+# MARK: - Token Type Functions
+
+def _is_a(token, token_type, value = None):
+    """Checks whether the specified token is the specified type and value, if a value is provided.
+
+    Args:
+        token: A token `struct`.
+        token_type: A `string` specifying the expected token type (i.e. value from `token_types`).
+        value: Optional. The expected token value.
+
+    Returns:
+        A `bool` value of True if the token is the specified type/value. Otherwise, it returns False.
+    """
+    if token.type != token_type:
+        return False
+    if value != None and token.value != value:
+        return False
+    return True
+
 # MARK: - Token List Functions
 
 def _get_token(tokens, idx, count = None):
@@ -230,6 +249,9 @@ tokens = struct(
     exclamation_point = _create_exclamation_point,
     comma = _create_comma,
     period = _create_period,
+
+    # Token Functions
+    is_a = _is_a,
 
     # Token List Functions
     get = _get_token,

--- a/spm/internal/modulemap_parser/tokens.bzl
+++ b/spm/internal/modulemap_parser/tokens.bzl
@@ -39,30 +39,25 @@ def _create_token_type(name, value_type_or_set = type(None)):
     )
     return name
 
-def _create(token_type_or_name, value = None):
+def _create(token_type_name, value = None):
     """Create a token of the specified type.
 
     Args:
-        token_type_or_name: The token type or the name of the token type.
+        token_type_name: The token type or the name of the token type.
         value: Optional. The value associated with the token.
 
     Returns:
         A `struct` representing the token.
     """
-
-    # if types.is_string(token_type_or_name):
-    #     token_type = _token_types_dict[token_type_or_name]
-    # else:
-    #     token_type = token_type_or_name
-    validation_info = _token_types_validation[token_type_or_name]
+    validation_info = _token_types_validation[token_type_name]
     if not validation_info:
-        fail("Invalid token type name", token_type_or_name)
+        fail("Invalid token type name", token_type_name)
 
     if not partial.call(validation_info.is_valid_value_fn, value):
-        fail("Invalid value for token type", token_type_or_name, value)
+        fail("Invalid value for token type", token_type_name, value)
 
     return struct(
-        type = token_type_or_name,
+        type = token_type_name,
         value = value,
     )
 

--- a/spm/internal/modulemap_parser/tokens.bzl
+++ b/spm/internal/modulemap_parser/tokens.bzl
@@ -86,6 +86,10 @@ RESERVED_WORDS = sets.make([_reserved_words_dict[k] for k in _reserved_words_dic
 
 # MARK: - Operators
 
+_operators = struct(
+    asterisk = "*",
+)
+
 # NOTE: This is meant to be a set of the operators not a set of the operator characters.
 # For instance, operator characters could be ["*", "=", "+"] while the list of operators
 # could be ["*", "+", "+=", "="].
@@ -226,6 +230,8 @@ def _get_token_as(tokens, idx, token_type, value = None, count = None):
 # MARK: - Tokens Namespace
 
 reserved_words = _reserved_words
+
+operators = _operators
 
 token_types = _token_types
 

--- a/spm/internal/modulemap_parser/tokens.bzl
+++ b/spm/internal/modulemap_parser/tokens.bzl
@@ -82,7 +82,7 @@ _reserved_words = struct(
     use = "use",
 )
 _reserved_words_dict = structs.to_dict(_reserved_words)
-RESERVED_WORDS = sets.make([_reserved_words_dict[k] for k in _reserved_words_dict])
+_reserved_words_set = sets.make([_reserved_words_dict[k] for k in _reserved_words_dict])
 
 # MARK: - Operators
 
@@ -93,20 +93,20 @@ _operators = struct(
 # NOTE: This is meant to be a set of the operators not a set of the operator characters.
 # For instance, operator characters could be ["*", "=", "+"] while the list of operators
 # could be ["*", "+", "+=", "="].
-OPERATORS = sets.make(["*"])
+_operators_set = sets.make(["*"])
 
 # MARK: - Token Types
 
 _token_types_validation = dict()
 
 _token_types = struct(
-    reserved = _create_token_type("reserved", RESERVED_WORDS),
+    reserved = _create_token_type("reserved", _reserved_words_set),
     identifier = _create_token_type("identifier", "string"),
     string_literal = _create_token_type("string_literal", "string"),
     integer_literal = _create_token_type("integer_literal", "int"),
     float_literal = _create_token_type("float_literal", "float"),
     comment = _create_token_type("comment", "string"),
-    operator = _create_token_type("operator", OPERATORS),
+    operator = _create_token_type("operator", _operators_set),
     curly_bracket_open = _create_token_type("curly_bracket_open"),
     curly_bracket_close = _create_token_type("curly_bracket_close"),
     newline = _create_token_type("newline"),
@@ -230,15 +230,13 @@ def _get_token_as(tokens, idx, token_type, value = None, count = None):
 # MARK: - Tokens Namespace
 
 reserved_words = _reserved_words
+reserved_words_set = _reserved_words_set
 
 operators = _operators
 
 token_types = _token_types
 
 tokens = struct(
-    # Specialty sets
-    reserved_words = RESERVED_WORDS,
-
     # Token Factories
     reserved = _create_reserved,
     identifier = _create_identifier,

--- a/spm/internal/modulemap_parser/tokens.bzl
+++ b/spm/internal/modulemap_parser/tokens.bzl
@@ -113,8 +113,6 @@ _token_types = struct(
     period = _create_token_type("period"),
 )
 
-# _token_types_dict = structs.to_dict(_token_types)
-
 def _create_reserved(value):
     return _create(_token_types.reserved, value)
 

--- a/spm/internal/modulemap_parser/tokens.bzl
+++ b/spm/internal/modulemap_parser/tokens.bzl
@@ -182,15 +182,15 @@ def _get_token(tokens, idx, count = None):
         return None, errors.new("No more tokens available. count: %s, idx: %s" % (count, idx))
     return tokens[idx], None
 
-def _get_token_as(tokens, idx, expected_type, expected_value = None, count = None):
+def _get_token_as(tokens, idx, token_type, value = None, count = None):
     """Returns the next token in the list if it matches the specified type and, optionally, the
     specified value.
 
     Args:
         tokens: A `list` of tokens.
         idx: The current index.
-        expected_type: The expxected token type `struct`.
-        expected_value: Optional. The expected token value.
+        token_type: The expxected token type `struct`.
+        value: Optional. The expected token value.
         count: Optional. The number of tokens in the list.
 
     Returns:
@@ -200,10 +200,10 @@ def _get_token_as(tokens, idx, expected_type, expected_value = None, count = Non
     token, err = _get_token(tokens, idx, count = count)
     if err:
         return None, err
-    if token.type != expected_type:
-        return None, errors.new("Expected type %s, but was %s" % (expected_type, token.type))
-    if expected_value != None and token.value != expected_value:
-        return None, errors.new("Expected value %s, but was %s" % (expected_value, token.value))
+    if token.type != token_type:
+        return None, errors.new("Expected type %s, but was %s" % (token_type, token.type))
+    if value != None and token.value != value:
+        return None, errors.new("Expected value %s, but was %s" % (value, token.value))
     return token, None
 
 # MARK: - Tokens Namespace

--- a/spm/internal/modulemap_parser/tokens.bzl
+++ b/spm/internal/modulemap_parser/tokens.bzl
@@ -206,10 +206,11 @@ def _get_token_as(tokens, idx, token_type, value = None, count = None):
 
 # MARK: - Tokens Namespace
 
-tokens = struct(
-    # Token Types
-    types = _token_types,
+reserved_words = _reserved_words
 
+token_types = _token_types
+
+tokens = struct(
     # Specialty sets
     reserved_words = RESERVED_WORDS,
 
@@ -234,5 +235,3 @@ tokens = struct(
     get = _get_token,
     get_as = _get_token_as,
 )
-
-reserved_words = _reserved_words

--- a/spm/internal/modulemap_parser/tokens.bzl
+++ b/spm/internal/modulemap_parser/tokens.bzl
@@ -1,3 +1,4 @@
+load(":errors.bzl", "errors")
 load("@bazel_skylib//lib:partial.bzl", "partial")
 load("@bazel_skylib//lib:sets.bzl", "sets")
 load("@bazel_skylib//lib:structs.bzl", "structs")
@@ -178,6 +179,27 @@ def _create_comma():
 def _create_period():
     return _create(_token_types.period)
 
+# MARK: - Token List Functions
+
+def _next_token(tokens, idx, tokens_len = None):
+    """Returns the next token in the list.
+
+    Args:
+        tokens: A `list` of tokens.
+        idx: The current index.
+        tokens_len: Optional. The number of tokens in the list.
+
+    Returns:
+        A `tuple` where the first item is the next token and the second item is an error, if any
+        occurred.
+    """
+    if not tokens_len:
+        tokens_len = len(tokens)
+    next_idx = idx + 1
+    if next_idx >= tokens_len:
+        return None, errors.new("No more tokens available.")
+    return tokens[next_idx], None
+
 # MARK: - Tokens Namespace
 
 tokens = struct(
@@ -203,6 +225,9 @@ tokens = struct(
     exclamation_point = _create_exclamation_point,
     comma = _create_comma,
     period = _create_period,
+
+    # Token List Functions
+    next = _next_token,
 )
 
 reserved_words = _reserved_words

--- a/spm/internal/modulemap_parser/tokens.bzl
+++ b/spm/internal/modulemap_parser/tokens.bzl
@@ -181,24 +181,48 @@ def _create_period():
 
 # MARK: - Token List Functions
 
-def _next_token(tokens, idx, tokens_len = None):
+def _next_token(tokens, idx, count = None):
     """Returns the next token in the list.
 
     Args:
         tokens: A `list` of tokens.
         idx: The current index.
-        tokens_len: Optional. The number of tokens in the list.
+        count: Optional. The number of tokens in the list.
 
     Returns:
         A `tuple` where the first item is the next token and the second item is an error, if any
         occurred.
     """
-    if not tokens_len:
-        tokens_len = len(tokens)
+    if not count:
+        count = len(tokens)
     next_idx = idx + 1
-    if next_idx >= tokens_len:
+    if next_idx >= count:
         return None, errors.new("No more tokens available.")
     return tokens[next_idx], None
+
+def _next_token_as(tokens, idx, expected_type, expected_value = None, count = None):
+    """Returns the next token in the list if it matches the specified type and, optionally, the
+    specified value.
+
+    Args:
+        tokens: A `list` of tokens.
+        idx: The current index.
+        expected_type: The expxected token type `struct`.
+        expected_value: Optional. The expected token value.
+        count: Optional. The number of tokens in the list.
+
+    Returns:
+        A `tuple` where the first item is the next token and the second item is an error, if any
+        occurred.
+    """
+    token, err = _next_token(tokens, idx, count = count)
+    if err:
+        return None, err
+    if token.type != expected_type:
+        return None, errors.new("Expected type %s, but was %s" % (expected_type, token.type))
+    if expected_value != None and token.value != expected_value:
+        return None, errors.new("Expected value %s, but was %s" % (expected_value, token.value))
+    return token, None
 
 # MARK: - Tokens Namespace
 
@@ -228,6 +252,7 @@ tokens = struct(
 
     # Token List Functions
     next = _next_token,
+    next_as = _next_token_as,
 )
 
 reserved_words = _reserved_words

--- a/swift/Sources/GenerateClangModule/BUILD.bazel
+++ b/swift/Sources/GenerateClangModule/BUILD.bazel
@@ -1,8 +1,0 @@
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary")
-
-swift_binary(
-    name = "GenerateClangModule",
-    srcs = ["main.swift"],
-    visibility = ["//visibility:public"],
-    deps = [],
-)

--- a/swift/Sources/GenerateClangModule/main.swift
+++ b/swift/Sources/GenerateClangModule/main.swift
@@ -1,1 +1,0 @@
-Swift.print("Generating an awesome clang module declaration.")

--- a/test/modulemap_parser/BUILD.bazel
+++ b/test/modulemap_parser/BUILD.bazel
@@ -4,6 +4,7 @@ load(":parser_tests.bzl", "parser_test_suite")
 load(":tokenizer_tests.bzl", "tokenizer_test_suite")
 load(":tokens_tests.bzl", "tokens_test_suite")
 load(":collect_extern_module_tests.bzl", "collect_extern_module_test_suite")
+load(":collect_module_tests.bzl", "collect_module_test_suite")
 
 errors_test_suite()
 
@@ -16,3 +17,5 @@ tokenizer_test_suite()
 parser_test_suite()
 
 collect_extern_module_test_suite()
+
+collect_module_test_suite()

--- a/test/modulemap_parser/BUILD.bazel
+++ b/test/modulemap_parser/BUILD.bazel
@@ -3,6 +3,7 @@ load(":errors_tests.bzl", "errors_test_suite")
 load(":parser_tests.bzl", "parser_test_suite")
 load(":tokenizer_tests.bzl", "tokenizer_test_suite")
 load(":tokens_tests.bzl", "tokens_test_suite")
+load(":collect_extern_module_tests.bzl", "collect_extern_module_test_suite")
 
 errors_test_suite()
 
@@ -13,3 +14,5 @@ tokens_test_suite()
 tokenizer_test_suite()
 
 parser_test_suite()
+
+collect_extern_module_test_suite()

--- a/test/modulemap_parser/BUILD.bazel
+++ b/test/modulemap_parser/BUILD.bazel
@@ -6,6 +6,7 @@ load(":tokens_tests.bzl", "tokens_test_suite")
 load(":collect_extern_module_tests.bzl", "collect_extern_module_test_suite")
 load(":collect_module_tests.bzl", "collect_module_test_suite")
 load(":collect_module_member_tests.bzl", "collect_module_member_test_suite")
+load(":collect_header_declaration_tests.bzl", "collect_header_declaration_test_suite")
 
 errors_test_suite()
 
@@ -22,3 +23,5 @@ collect_extern_module_test_suite()
 collect_module_test_suite()
 
 collect_module_member_test_suite()
+
+collect_header_declaration_test_suite()

--- a/test/modulemap_parser/BUILD.bazel
+++ b/test/modulemap_parser/BUILD.bazel
@@ -7,6 +7,7 @@ load(":collect_extern_module_tests.bzl", "collect_extern_module_test_suite")
 load(":collect_module_tests.bzl", "collect_module_test_suite")
 load(":collect_module_member_tests.bzl", "collect_module_member_test_suite")
 load(":collect_header_declaration_tests.bzl", "collect_header_declaration_test_suite")
+load(":collect_umbrella_dir_declaration_tests.bzl", "collect_umbrella_dir_declaration_test_suite")
 
 errors_test_suite()
 
@@ -25,3 +26,5 @@ collect_module_test_suite()
 collect_module_member_test_suite()
 
 collect_header_declaration_test_suite()
+
+collect_umbrella_dir_declaration_test_suite()

--- a/test/modulemap_parser/BUILD.bazel
+++ b/test/modulemap_parser/BUILD.bazel
@@ -5,6 +5,7 @@ load(":tokenizer_tests.bzl", "tokenizer_test_suite")
 load(":tokens_tests.bzl", "tokens_test_suite")
 load(":collect_extern_module_tests.bzl", "collect_extern_module_test_suite")
 load(":collect_module_tests.bzl", "collect_module_test_suite")
+load(":collect_module_member_tests.bzl", "collect_module_member_test_suite")
 
 errors_test_suite()
 
@@ -19,3 +20,5 @@ parser_test_suite()
 collect_extern_module_test_suite()
 
 collect_module_test_suite()
+
+collect_module_member_test_suite()

--- a/test/modulemap_parser/BUILD.bazel
+++ b/test/modulemap_parser/BUILD.bazel
@@ -8,6 +8,7 @@ load(":collect_module_tests.bzl", "collect_module_test_suite")
 load(":collect_module_member_tests.bzl", "collect_module_member_test_suite")
 load(":collect_header_declaration_tests.bzl", "collect_header_declaration_test_suite")
 load(":collect_umbrella_dir_declaration_tests.bzl", "collect_umbrella_dir_declaration_test_suite")
+load(":collect_export_declaration_tests.bzl", "collect_export_declaration_test_suite")
 
 errors_test_suite()
 
@@ -28,3 +29,5 @@ collect_module_member_test_suite()
 collect_header_declaration_test_suite()
 
 collect_umbrella_dir_declaration_test_suite()
+
+collect_export_declaration_test_suite()

--- a/test/modulemap_parser/BUILD.bazel
+++ b/test/modulemap_parser/BUILD.bazel
@@ -1,6 +1,12 @@
-load(":tokens_tests.bzl", "tokens_test_suite")
+load(":declarations_tests.bzl", "declarations_test_suite")
+load(":parser_tests.bzl", "parser_test_suite")
 load(":tokenizer_tests.bzl", "tokenizer_test_suite")
+load(":tokens_tests.bzl", "tokens_test_suite")
+
+declarations_test_suite()
 
 tokens_test_suite()
 
 tokenizer_test_suite()
+
+parser_test_suite()

--- a/test/modulemap_parser/BUILD.bazel
+++ b/test/modulemap_parser/BUILD.bazel
@@ -1,7 +1,10 @@
 load(":declarations_tests.bzl", "declarations_test_suite")
+load(":errors_tests.bzl", "errors_test_suite")
 load(":parser_tests.bzl", "parser_test_suite")
 load(":tokenizer_tests.bzl", "tokenizer_test_suite")
 load(":tokens_tests.bzl", "tokens_test_suite")
+
+errors_test_suite()
 
 declarations_test_suite()
 

--- a/test/modulemap_parser/BUILD.bazel
+++ b/test/modulemap_parser/BUILD.bazel
@@ -1,3 +1,6 @@
 load(":tokens_tests.bzl", "tokens_test_suite")
+load(":tokenizer_tests.bzl", "tokenizer_test_suite")
 
 tokens_test_suite()
+
+tokenizer_test_suite()

--- a/test/modulemap_parser/collect_export_declaration_tests.bzl
+++ b/test/modulemap_parser/collect_export_declaration_tests.bzl
@@ -1,16 +1,70 @@
+load("//spm/internal/modulemap_parser:declarations.bzl", "declarations")
+load(":test_helpers.bzl", "do_failing_parse_test", "do_parse_test")
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 
-def _parse_test(ctx):
+def _collect_export_declaration_test(ctx):
     env = unittest.begin(ctx)
 
-    unittest.fail(env, "IMPLEMENT ME!")
+    do_parse_test(
+        env,
+        "module with wildcard export",
+        text = """
+        module MyModule {
+            export *
+        }
+        """,
+        expected = [
+            declarations.module(
+                module_id = "MyModule",
+                members = [
+                    declarations.export(wildcard = True),
+                ],
+            ),
+        ],
+    )
+
+    do_parse_test(
+        env,
+        "module with export identifiers",
+        text = """
+        module MyModule {
+            export foo.bar
+        }
+        """,
+        expected = [
+            declarations.module(
+                module_id = "MyModule",
+                members = [
+                    declarations.export(identifiers = ["foo", "bar"]),
+                ],
+            ),
+        ],
+    )
+
+    do_parse_test(
+        env,
+        "module with export identifiers",
+        text = """
+        module MyModule {
+            export foo.bar.*
+        }
+        """,
+        expected = [
+            declarations.module(
+                module_id = "MyModule",
+                members = [
+                    declarations.export(identifiers = ["foo", "bar"], wildcard = True),
+                ],
+            ),
+        ],
+    )
 
     return unittest.end(env)
 
-parse_test = unittest.make(_parse_test)
+collect_export_declaration_test = unittest.make(_collect_export_declaration_test)
 
 def collect_export_declaration_test_suite():
     return unittest.suite(
         "collect_export_declaration_tests",
-        parse_test,
+        collect_export_declaration_test,
     )

--- a/test/modulemap_parser/collect_export_declaration_tests.bzl
+++ b/test/modulemap_parser/collect_export_declaration_tests.bzl
@@ -1,0 +1,16 @@
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+
+def _parse_test(ctx):
+    env = unittest.begin(ctx)
+
+    unittest.fail(env, "IMPLEMENT ME!")
+
+    return unittest.end(env)
+
+parse_test = unittest.make(_parse_test)
+
+def collect_export_declaration_test_suite():
+    return unittest.suite(
+        "collect_export_declaration_tests",
+        parse_test,
+    )

--- a/test/modulemap_parser/collect_extern_module_tests.bzl
+++ b/test/modulemap_parser/collect_extern_module_tests.bzl
@@ -1,33 +1,27 @@
-load("@bazel_skylib//lib:unittest.bzl", "unittest")
 load("//spm/internal/modulemap_parser:declarations.bzl", "declarations")
 load(":test_helpers.bzl", "do_parse_test")
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 
 def _parse_test(ctx):
     env = unittest.begin(ctx)
 
     do_parse_test(
         env,
-        "parse empty string",
+        "parse extern module",
         text = """
+        extern module MyModule "path/to/definition"
         """,
-        expected = [],
-    )
-
-    do_parse_test(
-        env,
-        "parse just newline",
-        text = """
-
-        """,
-        expected = [],
+        expected = [
+            declarations.extern_module("MyModule", "path/to/definition"),
+        ],
     )
 
     return unittest.end(env)
 
 parse_test = unittest.make(_parse_test)
 
-def parser_test_suite():
+def collect_extern_module_test_suite():
     return unittest.suite(
-        "parser_tests",
+        "collect_extern_module_tests",
         parse_test,
     )

--- a/test/modulemap_parser/collect_header_declaration_tests.bzl
+++ b/test/modulemap_parser/collect_header_declaration_tests.bzl
@@ -23,6 +23,27 @@ def _parse_test(ctx):
         ],
     )
 
+    do_parse_test(
+        env,
+        "module with single header and attributes (ignored)",
+        text = """
+        module MyModule {
+            header "path/to/header.h" {
+                size 1234
+                mtime 5678
+            }
+        }
+        """,
+        expected = [
+            declarations.module(
+                module_id = "MyModule",
+                members = [
+                    declarations.single_header("path/to/header.h"),
+                ],
+            ),
+        ],
+    )
+
     return unittest.end(env)
 
 parse_test = unittest.make(_parse_test)

--- a/test/modulemap_parser/collect_header_declaration_tests.bzl
+++ b/test/modulemap_parser/collect_header_declaration_tests.bzl
@@ -2,7 +2,7 @@ load("//spm/internal/modulemap_parser:declarations.bzl", "declarations")
 load(":test_helpers.bzl", "do_failing_parse_test", "do_parse_test")
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 
-def _parse_test(ctx):
+def _parse_single_header_test(ctx):
     env = unittest.begin(ctx)
 
     do_parse_test(
@@ -82,10 +82,30 @@ def _parse_test(ctx):
 
     return unittest.end(env)
 
-parse_test = unittest.make(_parse_test)
+parse_single_header_test = unittest.make(_parse_single_header_test)
+
+def _parse_umbrella_header_test(ctx):
+    env = unittest.begin(ctx)
+
+    unittest.fail(env, "IMPLEMENT ME!")
+
+    return unittest.end(env)
+
+parse_umbrella_header_test = unittest.make(_parse_umbrella_header_test)
+
+def _parse_exclude_header_test(ctx):
+    env = unittest.begin(ctx)
+
+    unittest.fail(env, "IMPLEMENT ME!")
+
+    return unittest.end(env)
+
+parse_exclude_header_test = unittest.make(_parse_exclude_header_test)
 
 def collect_header_declaration_test_suite():
     return unittest.suite(
         "collect_header_declaration_tests",
-        parse_test,
+        parse_single_header_test,
+        parse_umbrella_header_test,
+        parse_exclude_header_test,
     )

--- a/test/modulemap_parser/collect_header_declaration_tests.bzl
+++ b/test/modulemap_parser/collect_header_declaration_tests.bzl
@@ -87,7 +87,23 @@ parse_single_header_test = unittest.make(_parse_single_header_test)
 def _parse_umbrella_header_test(ctx):
     env = unittest.begin(ctx)
 
-    unittest.fail(env, "IMPLEMENT ME!")
+    do_parse_test(
+        env,
+        "module with umbrella header",
+        text = """
+        module MyModule {
+            umbrella header "path/to/header.h"
+        }
+        """,
+        expected = [
+            declarations.module(
+                module_id = "MyModule",
+                members = [
+                    declarations.umbrella_header("path/to/header.h"),
+                ],
+            ),
+        ],
+    )
 
     return unittest.end(env)
 
@@ -96,7 +112,23 @@ parse_umbrella_header_test = unittest.make(_parse_umbrella_header_test)
 def _parse_exclude_header_test(ctx):
     env = unittest.begin(ctx)
 
-    unittest.fail(env, "IMPLEMENT ME!")
+    do_parse_test(
+        env,
+        "module with exclude header",
+        text = """
+        module MyModule {
+            exclude header "path/to/header.h"
+        }
+        """,
+        expected = [
+            declarations.module(
+                module_id = "MyModule",
+                members = [
+                    declarations.exclude_header("path/to/header.h"),
+                ],
+            ),
+        ],
+    )
 
     return unittest.end(env)
 

--- a/test/modulemap_parser/collect_header_declaration_tests.bzl
+++ b/test/modulemap_parser/collect_header_declaration_tests.bzl
@@ -44,10 +44,6 @@ def _parse_test(ctx):
         ],
     )
 
-    # DEBUG BEGIN
-    print("*** CHUCK START")
-    # DEBUG END
-
     do_parse_test(
         env,
         "module with single header, as private",
@@ -66,9 +62,23 @@ def _parse_test(ctx):
         ],
     )
 
-    # DEBUG BEGIN
-    print("*** CHUCK END")
-    # DEBUG END
+    do_parse_test(
+        env,
+        "module with single header, as textual",
+        text = """
+        module MyModule {
+            textual header "path/to/header.h"
+        }
+        """,
+        expected = [
+            declarations.module(
+                module_id = "MyModule",
+                members = [
+                    declarations.single_header("path/to/header.h", textual = True),
+                ],
+            ),
+        ],
+    )
 
     return unittest.end(env)
 

--- a/test/modulemap_parser/collect_header_declaration_tests.bzl
+++ b/test/modulemap_parser/collect_header_declaration_tests.bzl
@@ -44,6 +44,32 @@ def _parse_test(ctx):
         ],
     )
 
+    # DEBUG BEGIN
+    print("*** CHUCK START")
+    # DEBUG END
+
+    do_parse_test(
+        env,
+        "module with single header, as private",
+        text = """
+        module MyModule {
+            private header "path/to/header.h"
+        }
+        """,
+        expected = [
+            declarations.module(
+                module_id = "MyModule",
+                members = [
+                    declarations.single_header("path/to/header.h", private = True),
+                ],
+            ),
+        ],
+    )
+
+    # DEBUG BEGIN
+    print("*** CHUCK END")
+    # DEBUG END
+
     return unittest.end(env)
 
 parse_test = unittest.make(_parse_test)

--- a/test/modulemap_parser/collect_header_declaration_tests.bzl
+++ b/test/modulemap_parser/collect_header_declaration_tests.bzl
@@ -1,9 +1,27 @@
+load("//spm/internal/modulemap_parser:declarations.bzl", "declarations")
+load(":test_helpers.bzl", "do_failing_parse_test", "do_parse_test")
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 
 def _parse_test(ctx):
     env = unittest.begin(ctx)
 
-    unittest.fail(env, "IMPLEMENT ME!")
+    do_parse_test(
+        env,
+        "module with single header, no qualifiers",
+        text = """
+        module MyModule {
+            header "path/to/header.h"
+        }
+        """,
+        expected = [
+            declarations.module(
+                module_id = "MyModule",
+                members = [
+                    declarations.single_header("path/to/header.h"),
+                ],
+            ),
+        ],
+    )
 
     return unittest.end(env)
 

--- a/test/modulemap_parser/collect_header_declaration_tests.bzl
+++ b/test/modulemap_parser/collect_header_declaration_tests.bzl
@@ -1,0 +1,16 @@
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+
+def _parse_test(ctx):
+    env = unittest.begin(ctx)
+
+    unittest.fail(env, "IMPLEMENT ME!")
+
+    return unittest.end(env)
+
+parse_test = unittest.make(_parse_test)
+
+def collect_header_declaration_test_suite():
+    return unittest.suite(
+        "collect_header_declaration_tests",
+        parse_test,
+    )

--- a/test/modulemap_parser/collect_module_member_tests.bzl
+++ b/test/modulemap_parser/collect_module_member_tests.bzl
@@ -1,0 +1,17 @@
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load(":test_helpers.bzl", "do_failing_parse_test", "do_parse_test")
+
+def _parse_newline_in_module_member_test(ctx):
+    env = unittest.begin(ctx)
+
+    unittest.fail(env, "IMPLEMENT ME!")
+
+    return unittest.end(env)
+
+parse_newline_in_module_member_test = unittest.make(_parse_newline_in_module_member_test)
+
+def collect_module_member_test_suite():
+    return unittest.suite(
+        "collect_module_member_tests",
+        parse_newline_in_module_member_test,
+    )

--- a/test/modulemap_parser/collect_module_member_tests.bzl
+++ b/test/modulemap_parser/collect_module_member_tests.bzl
@@ -1,10 +1,28 @@
+load("//spm/internal/modulemap_parser:declarations.bzl", "declarations")
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load(":test_helpers.bzl", "do_failing_parse_test", "do_parse_test")
 
 def _parse_newline_in_module_member_test(ctx):
     env = unittest.begin(ctx)
 
-    unittest.fail(env, "IMPLEMENT ME!")
+    do_parse_test(
+        env,
+        "module with newlines in members area",
+        text = """
+        module MyModule {
+
+        }
+        """,
+        expected = [
+            declarations.module(
+                module_id = "MyModule",
+                framework = False,
+                explicit = False,
+                attributes = [],
+                members = [],
+            ),
+        ],
+    )
 
     return unittest.end(env)
 

--- a/test/modulemap_parser/collect_module_tests.bzl
+++ b/test/modulemap_parser/collect_module_tests.bzl
@@ -89,8 +89,18 @@ def _parse_test(ctx):
 
 parse_test = unittest.make(_parse_test)
 
+def _parse_with_submodules_test(ctx):
+    env = unittest.begin(ctx)
+
+    unittest.fail(env, "IMPLEMENT ME!")
+
+    return unittest.end(env)
+
+parse_with_submodules_test = unittest.make(_parse_with_submodules_test)
+
 def collect_module_test_suite():
     return unittest.suite(
         "collect_module_tests",
         parse_test,
+        parse_with_submodules_test,
     )

--- a/test/modulemap_parser/collect_module_tests.bzl
+++ b/test/modulemap_parser/collect_module_tests.bzl
@@ -89,71 +89,8 @@ def _collect_module_test(ctx):
 
 collect_module_test = unittest.make(_collect_module_test)
 
-def _collect_submodules_test(ctx):
-    env = unittest.begin(ctx)
-
-    do_parse_test(
-        env,
-        "module with submodule",
-        text = """
-        module MyModule {
-            module SubModule {
-              header "SubModule.h"
-              export *
-            }
-        }
-        """,
-        expected = [
-            declarations.module(
-                module_id = "MyModule",
-                members = [
-                    declarations.module(
-                        module_id = "SubModule",
-                        members = [
-                            declarations.single_header(path = "SubModule.h"),
-                            declarations.export(wildcard = True),
-                        ],
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    do_parse_test(
-        env,
-        "module with explicit submodule",
-        text = """
-        module MyModule {
-            explicit module SubModule {
-              header "SubModule.h"
-              export *
-            }
-        }
-        """,
-        expected = [
-            declarations.module(
-                module_id = "MyModule",
-                members = [
-                    declarations.module(
-                        module_id = "SubModule",
-                        explicit = True,
-                        members = [
-                            declarations.single_header(path = "SubModule.h"),
-                            declarations.export(wildcard = True),
-                        ],
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    return unittest.end(env)
-
-collect_submodules_test = unittest.make(_collect_submodules_test)
-
 def collect_module_test_suite():
     return unittest.suite(
         "collect_module_tests",
         collect_module_test,
-        collect_submodules_test,
     )

--- a/test/modulemap_parser/collect_module_tests.bzl
+++ b/test/modulemap_parser/collect_module_tests.bzl
@@ -67,15 +67,23 @@ def _parse_test(ctx):
                        (tokens.identifier("unexpected")),
     )
 
-    # do_failing_parse_test(
-    #     env,
-    #     "module with missing module id",
-    #     text = """
-    #     module {}
-    #     """,
-    #     expected_err = "Unexpected prefix token collecting module declaration. token: %s" %
-    #                    (tokens.identifier("unexpected")),
-    # )
+    do_failing_parse_test(
+        env,
+        "module with missing module id",
+        text = """
+        module {}
+        """,
+        expected_err = "Expected type identifier, but was curly_bracket_open",
+    )
+
+    do_failing_parse_test(
+        env,
+        "module with malformed attribute",
+        text = """
+        module MyModule [system {}
+        """,
+        expected_err = "Expected type square_bracket_close, but was curly_bracket_open",
+    )
 
     return unittest.end(env)
 

--- a/test/modulemap_parser/collect_module_tests.bzl
+++ b/test/modulemap_parser/collect_module_tests.bzl
@@ -67,6 +67,16 @@ def _parse_test(ctx):
                        (tokens.identifier("unexpected")),
     )
 
+    # do_failing_parse_test(
+    #     env,
+    #     "module with missing module id",
+    #     text = """
+    #     module {}
+    #     """,
+    #     expected_err = "Unexpected prefix token collecting module declaration. token: %s" %
+    #                    (tokens.identifier("unexpected")),
+    # )
+
     return unittest.end(env)
 
 parse_test = unittest.make(_parse_test)

--- a/test/modulemap_parser/collect_module_tests.bzl
+++ b/test/modulemap_parser/collect_module_tests.bzl
@@ -22,6 +22,40 @@ def _parse_test(ctx):
         ],
     )
 
+    do_parse_test(
+        env,
+        "module with qualifiers",
+        text = """
+        framework module MyModule {}
+        """,
+        expected = [
+            declarations.module(
+                module_id = "MyModule",
+                framework = True,
+                explicit = False,
+                attributes = [],
+                members = [],
+            ),
+        ],
+    )
+
+    do_parse_test(
+        env,
+        "module with attributes",
+        text = """
+        module MyModule [system] [extern_c] {}
+        """,
+        expected = [
+            declarations.module(
+                module_id = "MyModule",
+                framework = False,
+                explicit = False,
+                attributes = ["system", "extern_c"],
+                members = [],
+            ),
+        ],
+    )
+
     return unittest.end(env)
 
 parse_test = unittest.make(_parse_test)

--- a/test/modulemap_parser/collect_module_tests.bzl
+++ b/test/modulemap_parser/collect_module_tests.bzl
@@ -1,6 +1,7 @@
-load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//spm/internal/modulemap_parser:declarations.bzl", "declarations")
-load(":test_helpers.bzl", "do_parse_test")
+load("//spm/internal/modulemap_parser:tokens.bzl", "tokens")
+load(":test_helpers.bzl", "do_failing_parse_test", "do_parse_test")
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 
 def _parse_test(ctx):
     env = unittest.begin(ctx)
@@ -54,6 +55,16 @@ def _parse_test(ctx):
                 members = [],
             ),
         ],
+    )
+
+    do_failing_parse_test(
+        env,
+        "module with unexpected qualifier",
+        text = """
+        unexpected module MyModule {}
+        """,
+        expected_err = "Unexpected prefix token collecting module declaration. token: %s" %
+                       (tokens.identifier("unexpected")),
     )
 
     return unittest.end(env)

--- a/test/modulemap_parser/collect_module_tests.bzl
+++ b/test/modulemap_parser/collect_module_tests.bzl
@@ -1,0 +1,33 @@
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//spm/internal/modulemap_parser:declarations.bzl", "declarations")
+load(":test_helpers.bzl", "do_parse_test")
+
+def _parse_test(ctx):
+    env = unittest.begin(ctx)
+
+    do_parse_test(
+        env,
+        "module without qualifiers, attributes and members",
+        text = """
+        module MyModule {}
+        """,
+        expected = [
+            declarations.module(
+                module_id = "MyModule",
+                framework = False,
+                explicit = False,
+                attributes = [],
+                members = [],
+            ),
+        ],
+    )
+
+    return unittest.end(env)
+
+parse_test = unittest.make(_parse_test)
+
+def collect_module_test_suite():
+    return unittest.suite(
+        "collect_module_tests",
+        parse_test,
+    )

--- a/test/modulemap_parser/collect_umbrella_dir_declaration_tests.bzl
+++ b/test/modulemap_parser/collect_umbrella_dir_declaration_tests.bzl
@@ -1,0 +1,34 @@
+load("//spm/internal/modulemap_parser:declarations.bzl", "declarations")
+load(":test_helpers.bzl", "do_failing_parse_test", "do_parse_test")
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+
+def _parse_test(ctx):
+    env = unittest.begin(ctx)
+
+    do_parse_test(
+        env,
+        "module with umbrella dir",
+        text = """
+        module MyModule {
+            umbrella "path/to/header/files"
+        }
+        """,
+        expected = [
+            declarations.module(
+                module_id = "MyModule",
+                members = [
+                    declarations.single_header("path/to/header/files"),
+                ],
+            ),
+        ],
+    )
+
+    return unittest.end(env)
+
+parse_test = unittest.make(_parse_test)
+
+def collect_umbrella_dir_declaration_test_suite():
+    return unittest.suite(
+        "collect_umbrella_dir_declaration_tests",
+        parse_test,
+    )

--- a/test/modulemap_parser/collect_umbrella_dir_declaration_tests.bzl
+++ b/test/modulemap_parser/collect_umbrella_dir_declaration_tests.bzl
@@ -17,7 +17,7 @@ def _parse_test(ctx):
             declarations.module(
                 module_id = "MyModule",
                 members = [
-                    declarations.single_header("path/to/header/files"),
+                    declarations.umbrella_directory("path/to/header/files"),
                 ],
             ),
         ],

--- a/test/modulemap_parser/declarations_tests.bzl
+++ b/test/modulemap_parser/declarations_tests.bzl
@@ -1,0 +1,49 @@
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//spm/internal/modulemap_parser:declarations.bzl", "declarations")
+
+def _module_test(ctx):
+    env = unittest.begin(ctx)
+
+    expected = struct(
+        module_id = "MyModule",
+        explicit = True,
+        framework = False,
+        attributes = ["system", "extern_c"],
+        members = ["foo"],
+    )
+    result = declarations.module(
+        module_id = "MyModule",
+        explicit = True,
+        framework = False,
+        attributes = ["system", "extern_c"],
+        members = ["foo"],
+    )
+    asserts.equals(env, expected, result)
+
+    return unittest.end(env)
+
+module_test = unittest.make(_module_test)
+
+def _extern_module_test(ctx):
+    env = unittest.begin(ctx)
+
+    expected = struct(
+        module_id = "MyModule",
+        definition_path = "path/to/definition",
+    )
+    result = declarations.extern_module(
+        module_id = "MyModule",
+        definition_path = "path/to/definition",
+    )
+    asserts.equals(env, expected, result)
+
+    return unittest.end(env)
+
+extern_module_test = unittest.make(_extern_module_test)
+
+def declarations_test_suite():
+    return unittest.suite(
+        "declarations_tests",
+        module_test,
+        extern_module_test,
+    )

--- a/test/modulemap_parser/declarations_tests.bzl
+++ b/test/modulemap_parser/declarations_tests.bzl
@@ -1,10 +1,15 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
-load("//spm/internal/modulemap_parser:declarations.bzl", "declarations")
+load(
+    "//spm/internal/modulemap_parser:declarations.bzl",
+    "declarations",
+    dts = "declaration_types",
+)
 
 def _module_test(ctx):
     env = unittest.begin(ctx)
 
     expected = struct(
+        decl_type = dts.module,
         module_id = "MyModule",
         explicit = True,
         framework = False,
@@ -28,6 +33,7 @@ def _extern_module_test(ctx):
     env = unittest.begin(ctx)
 
     expected = struct(
+        decl_type = dts.extern_module,
         module_id = "MyModule",
         definition_path = "path/to/definition",
     )
@@ -40,6 +46,23 @@ def _extern_module_test(ctx):
     return unittest.end(env)
 
 extern_module_test = unittest.make(_extern_module_test)
+
+def _header_test(ctx):
+    env = unittest.begin(ctx)
+
+    expected = struct(
+        decl_type = dts.single_header,
+        path = "path/to/header.h",
+        size = None,
+        mtime = None,
+        private = False,
+        textual = False,
+    )
+    actual = declarations
+
+    return unittest.end(env)
+
+header_test = unittest.make(_header_test)
 
 def declarations_test_suite():
     return unittest.suite(

--- a/test/modulemap_parser/declarations_tests.bzl
+++ b/test/modulemap_parser/declarations_tests.bzl
@@ -118,6 +118,24 @@ def _umbrella_directory_test(ctx):
 
 umbrella_directory_test = unittest.make(_umbrella_directory_test)
 
+def _export_test(ctx):
+    env = unittest.begin(ctx)
+
+    expected = struct(
+        decl_type = dts.export,
+        identifiers = ["foo"],
+        wildcard = True,
+    )
+    actual = declarations.export(
+        identifiers = ["foo"],
+        wildcard = True,
+    )
+    asserts.equals(env, expected, actual)
+
+    return unittest.end(env)
+
+export_test = unittest.make(_export_test)
+
 def declarations_test_suite():
     return unittest.suite(
         "declarations_tests",
@@ -127,4 +145,5 @@ def declarations_test_suite():
         umbrella_header_test,
         exclude_header_test,
         umbrella_directory_test,
+        export_test,
     )

--- a/test/modulemap_parser/declarations_tests.bzl
+++ b/test/modulemap_parser/declarations_tests.bzl
@@ -50,7 +50,19 @@ extern_module_test = unittest.make(_extern_module_test)
 def _single_header_test(ctx):
     env = unittest.begin(ctx)
 
-    unittest.fail(env, "IMPLEMENT ME!")
+    expected = struct(
+        decl_type = dts.single_header,
+        path = "path/to/header.h",
+        private = False,
+        textual = True,
+        attribs = None,
+    )
+    actual = declarations.single_header(
+        path = "path/to/header.h",
+        private = False,
+        textual = True,
+    )
+    asserts.equals(env, expected, actual)
 
     return unittest.end(env)
 
@@ -59,7 +71,15 @@ single_header_test = unittest.make(_single_header_test)
 def _umbrella_header_test(ctx):
     env = unittest.begin(ctx)
 
-    unittest.fail(env, "IMPLEMENT ME!")
+    expected = struct(
+        decl_type = dts.umbrella_header,
+        path = "path/to/header.h",
+        attribs = None,
+    )
+    actual = declarations.umbrella_header(
+        path = "path/to/header.h",
+    )
+    asserts.equals(env, expected, actual)
 
     return unittest.end(env)
 
@@ -68,7 +88,15 @@ umbrella_header_test = unittest.make(_umbrella_header_test)
 def _exclude_header_test(ctx):
     env = unittest.begin(ctx)
 
-    unittest.fail(env, "IMPLEMENT ME!")
+    expected = struct(
+        decl_type = dts.exclude_header,
+        path = "path/to/header.h",
+        attribs = None,
+    )
+    actual = declarations.exclude_header(
+        path = "path/to/header.h",
+    )
+    asserts.equals(env, expected, actual)
 
     return unittest.end(env)
 
@@ -77,7 +105,14 @@ exclude_header_test = unittest.make(_exclude_header_test)
 def _umbrella_directory_test(ctx):
     env = unittest.begin(ctx)
 
-    unittest.fail(env, "IMPLEMENT ME!")
+    expected = struct(
+        decl_type = dts.umbrella_directory,
+        path = "path/to/headers",
+    )
+    actual = declarations.umbrella_directory(
+        path = "path/to/headers",
+    )
+    asserts.equals(env, expected, actual)
 
     return unittest.end(env)
 

--- a/test/modulemap_parser/declarations_tests.bzl
+++ b/test/modulemap_parser/declarations_tests.bzl
@@ -47,26 +47,49 @@ def _extern_module_test(ctx):
 
 extern_module_test = unittest.make(_extern_module_test)
 
-def _header_test(ctx):
+def _single_header_test(ctx):
     env = unittest.begin(ctx)
 
-    expected = struct(
-        decl_type = dts.single_header,
-        path = "path/to/header.h",
-        size = None,
-        mtime = None,
-        private = False,
-        textual = False,
-    )
-    actual = declarations
+    unittest.fail(env, "IMPLEMENT ME!")
 
     return unittest.end(env)
 
-header_test = unittest.make(_header_test)
+single_header_test = unittest.make(_single_header_test)
+
+def _umbrella_header_test(ctx):
+    env = unittest.begin(ctx)
+
+    unittest.fail(env, "IMPLEMENT ME!")
+
+    return unittest.end(env)
+
+umbrella_header_test = unittest.make(_umbrella_header_test)
+
+def _exclude_header_test(ctx):
+    env = unittest.begin(ctx)
+
+    unittest.fail(env, "IMPLEMENT ME!")
+
+    return unittest.end(env)
+
+exclude_header_test = unittest.make(_exclude_header_test)
+
+def _umbrella_directory_test(ctx):
+    env = unittest.begin(ctx)
+
+    unittest.fail(env, "IMPLEMENT ME!")
+
+    return unittest.end(env)
+
+umbrella_directory_test = unittest.make(_umbrella_directory_test)
 
 def declarations_test_suite():
     return unittest.suite(
         "declarations_tests",
         module_test,
         extern_module_test,
+        single_header_test,
+        umbrella_header_test,
+        exclude_header_test,
+        umbrella_directory_test,
     )

--- a/test/modulemap_parser/errors_tests.bzl
+++ b/test/modulemap_parser/errors_tests.bzl
@@ -1,0 +1,16 @@
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+
+def _create_test(ctx):
+    env = unittest.begin(ctx)
+
+    unittest.fail(env, "IMPLEMENT ME!")
+
+    return unittest.end(env)
+
+create_test = unittest.make(_create_test)
+
+def errors_test_suite():
+    return unittest.suite(
+        "errors_tests",
+        create_test,
+    )

--- a/test/modulemap_parser/errors_tests.bzl
+++ b/test/modulemap_parser/errors_tests.bzl
@@ -1,9 +1,18 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//spm/internal/modulemap_parser:errors.bzl", "errors")
 
 def _create_test(ctx):
     env = unittest.begin(ctx)
 
-    unittest.fail(env, "IMPLEMENT ME!")
+    result = errors.new(
+        msg = "The message",
+        child_errors = ["child_error"],
+    )
+    expected = struct(
+        msg = "The message",
+        child_errors = ["child_error"],
+    )
+    asserts.equals(env, expected, result)
 
     return unittest.end(env)
 

--- a/test/modulemap_parser/parser_tests.bzl
+++ b/test/modulemap_parser/parser_tests.bzl
@@ -1,20 +1,7 @@
-load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("@bazel_skylib//lib:unittest.bzl", "unittest")
 load("//spm/internal/modulemap_parser:parser.bzl", "parser")
 load("//spm/internal/modulemap_parser:declarations.bzl", "declarations")
-
-def do_parse_test(env, msg, text, expected):
-    if not msg:
-        fail("A message must be provided.")
-    if not text:
-        fail("A text value must be provided.")
-    if not expected:
-        fail("An expected value must be provied.")
-
-    actual, err = parser.parse(text)
-    if err:
-        unittest.fail(env, "%s: An error occurred. %s" % (msg, err))
-        return
-    asserts.equals(env, expected, actual, msg)
+load(":test_helpers.bzl", "do_parse_test")
 
 def _parse_test(ctx):
     env = unittest.begin(ctx)

--- a/test/modulemap_parser/parser_tests.bzl
+++ b/test/modulemap_parser/parser_tests.bzl
@@ -4,13 +4,16 @@ load("//spm/internal/modulemap_parser:declarations.bzl", "declarations")
 
 def do_parse_test(env, msg, text, expected):
     if not msg:
-        unittest.fail("A message must be provided.")
+        fail("A message must be provided.")
     if not text:
-        unittest.fail("A text value must be provided.")
+        fail("A text value must be provided.")
     if not expected:
-        unittest.fail("An expected value must be provied.")
+        fail("An expected value must be provied.")
+
     actual, err = parser.parse(text)
-    asserts.false(env, err, msg)
+    if err:
+        unittest.fail(env, "%s: An error occurred. %s" % (msg, err))
+        return
     asserts.equals(env, expected, actual, msg)
 
 def _parse_test(ctx):
@@ -33,14 +36,6 @@ def _parse_test(ctx):
         expected = parser.result(),
     )
 
-    # text = """
-    # extern module MyModule "path/to/definition"
-    # """
-    # actual = parser.parse(text)
-    # expected = parser.result([
-    #     declarations.extern_module("MyModule", "path/to/definition"),
-    # ])
-    # asserts.equals(env, expected, actual, "parse extern module")
     do_parse_test(
         env,
         "parse extern module",

--- a/test/modulemap_parser/parser_tests.bzl
+++ b/test/modulemap_parser/parser_tests.bzl
@@ -1,5 +1,6 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//spm/internal/modulemap_parser:parser.bzl", "parser")
+load("//spm/internal/modulemap_parser:declarations.bzl", "declarations")
 
 def _parse_test(ctx):
     env = unittest.begin(ctx)
@@ -16,6 +17,15 @@ def _parse_test(ctx):
     actual = parser.parse(text)
     expected = parser.result()
     asserts.equals(env, expected, actual, "parse just newline")
+
+    text = """
+    extern module MyModule "path/to/definition"
+    """
+    actual = parser.parse(text)
+    expected = parser.result([
+        declarations.extern_module("MyModule", "path/to/definition"),
+    ])
+    asserts.equals(env, expected, actual, "parse extern module")
 
     return unittest.end(env)
 

--- a/test/modulemap_parser/parser_tests.bzl
+++ b/test/modulemap_parser/parser_tests.bzl
@@ -1,0 +1,16 @@
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+
+def _parse_test(ctx):
+    env = unittest.begin(ctx)
+
+    unittest.fail(env, "IMPLEMENT ME!")
+
+    return unittest.end(env)
+
+parse_test = unittest.make(_parse_test)
+
+def parser_test_suite():
+    return unittest.suite(
+        "parser_tests",
+        parse_test,
+    )

--- a/test/modulemap_parser/parser_tests.bzl
+++ b/test/modulemap_parser/parser_tests.bzl
@@ -2,30 +2,58 @@ load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//spm/internal/modulemap_parser:parser.bzl", "parser")
 load("//spm/internal/modulemap_parser:declarations.bzl", "declarations")
 
+def do_parse_test(env, msg, text, expected):
+    if not msg:
+        unittest.fail("A message must be provided.")
+    if not text:
+        unittest.fail("A text value must be provided.")
+    if not expected:
+        unittest.fail("An expected value must be provied.")
+    actual, err = parser.parse(text)
+    asserts.false(env, err, msg)
+    asserts.equals(env, expected, actual, msg)
+
 def _parse_test(ctx):
     env = unittest.begin(ctx)
 
-    text = """
-    """
-    actual = parser.parse(text)
-    expected = parser.result()
-    asserts.equals(env, expected, actual, "parse empty string")
+    # text = """
+    # """
+    # actual, err = parser.parse(text)
+    # asserts.false(env, err, "parse empty string")
+    # expected = parser.result()
+    # asserts.equals(env, expected, actual, "parse empty string")
+    do_parse_test(
+        env,
+        "parse empty string",
+        text = """
+        """,
+        expected = parser.result(),
+    )
 
-    text = """
+    # text = """
 
-    """
-    actual = parser.parse(text)
-    expected = parser.result()
-    asserts.equals(env, expected, actual, "parse just newline")
+    # """
+    # actual, err = parser.parse(text)
+    # asserts.false(env, err, "parse empty string")
+    # expected = parser.result()
+    # asserts.equals(env, expected, actual, "parse just newline")
+    do_parse_test(
+        env,
+        "parse just newline",
+        text = """
 
-    text = """
-    extern module MyModule "path/to/definition"
-    """
-    actual = parser.parse(text)
-    expected = parser.result([
-        declarations.extern_module("MyModule", "path/to/definition"),
-    ])
-    asserts.equals(env, expected, actual, "parse extern module")
+        """,
+        expected = parser.result(),
+    )
+
+    # text = """
+    # extern module MyModule "path/to/definition"
+    # """
+    # actual = parser.parse(text)
+    # expected = parser.result([
+    #     declarations.extern_module("MyModule", "path/to/definition"),
+    # ])
+    # asserts.equals(env, expected, actual, "parse extern module")
 
     return unittest.end(env)
 

--- a/test/modulemap_parser/parser_tests.bzl
+++ b/test/modulemap_parser/parser_tests.bzl
@@ -16,12 +16,6 @@ def do_parse_test(env, msg, text, expected):
 def _parse_test(ctx):
     env = unittest.begin(ctx)
 
-    # text = """
-    # """
-    # actual, err = parser.parse(text)
-    # asserts.false(env, err, "parse empty string")
-    # expected = parser.result()
-    # asserts.equals(env, expected, actual, "parse empty string")
     do_parse_test(
         env,
         "parse empty string",
@@ -30,13 +24,6 @@ def _parse_test(ctx):
         expected = parser.result(),
     )
 
-    # text = """
-
-    # """
-    # actual, err = parser.parse(text)
-    # asserts.false(env, err, "parse empty string")
-    # expected = parser.result()
-    # asserts.equals(env, expected, actual, "parse just newline")
     do_parse_test(
         env,
         "parse just newline",
@@ -54,6 +41,16 @@ def _parse_test(ctx):
     #     declarations.extern_module("MyModule", "path/to/definition"),
     # ])
     # asserts.equals(env, expected, actual, "parse extern module")
+    do_parse_test(
+        env,
+        "parse extern module",
+        text = """
+        extern module MyModule "path/to/definition"
+        """,
+        expected = parser.result([
+            declarations.extern_module("MyModule", "path/to/definition"),
+        ]),
+    )
 
     return unittest.end(env)
 

--- a/test/modulemap_parser/parser_tests.bzl
+++ b/test/modulemap_parser/parser_tests.bzl
@@ -1,9 +1,21 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//spm/internal/modulemap_parser:parser.bzl", "parser")
 
 def _parse_test(ctx):
     env = unittest.begin(ctx)
 
-    unittest.fail(env, "IMPLEMENT ME!")
+    text = """
+    """
+    actual = parser.parse(text)
+    expected = parser.result()
+    asserts.equals(env, expected, actual, "parse empty string")
+
+    text = """
+
+    """
+    actual = parser.parse(text)
+    expected = parser.result()
+    asserts.equals(env, expected, actual, "parse just newline")
 
     return unittest.end(env)
 

--- a/test/modulemap_parser/test_helpers.bzl
+++ b/test/modulemap_parser/test_helpers.bzl
@@ -1,0 +1,14 @@
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//spm/internal/modulemap_parser:parser.bzl", "parser")
+
+def do_parse_test(env, msg, text, expected):
+    if not msg:
+        fail("A message must be provided.")
+    if not text:
+        fail("A text value must be provided.")
+    if not expected:
+        fail("An expected value must be provied.")
+
+    actual, err = parser.parse(text)
+    asserts.equals(env, None, err, msg)
+    asserts.equals(env, expected, actual, msg)

--- a/test/modulemap_parser/test_helpers.bzl
+++ b/test/modulemap_parser/test_helpers.bzl
@@ -1,5 +1,7 @@
-load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//spm/internal/modulemap_parser:parser.bzl", "parser")
+load("@bazel_skylib//lib:types.bzl", "types")
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//spm/internal/modulemap_parser:errors.bzl", "errors")
 
 def do_parse_test(env, msg, text, expected):
     if msg == None:
@@ -12,3 +14,18 @@ def do_parse_test(env, msg, text, expected):
     actual, err = parser.parse(text)
     asserts.equals(env, None, err, msg)
     asserts.equals(env, expected, actual, msg)
+
+def do_failing_parse_test(env, msg, text, expected_err):
+    if msg == None:
+        fail("A message must be provided.")
+    if text == None:
+        fail("A text value must be provided.")
+    if expected_err == None:
+        fail("An err must be provied.")
+
+    if types.is_string(expected_err):
+        expected_err = errors.new(expected_err)
+
+    actual, err = parser.parse(text)
+    asserts.equals(env, expected_err, err, msg)
+    asserts.equals(env, None, actual, msg)

--- a/test/modulemap_parser/test_helpers.bzl
+++ b/test/modulemap_parser/test_helpers.bzl
@@ -2,11 +2,11 @@ load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//spm/internal/modulemap_parser:parser.bzl", "parser")
 
 def do_parse_test(env, msg, text, expected):
-    if not msg:
+    if msg == None:
         fail("A message must be provided.")
-    if not text:
+    if text == None:
         fail("A text value must be provided.")
-    if not expected:
+    if expected == None:
         fail("An expected value must be provied.")
 
     actual, err = parser.parse(text)

--- a/test/modulemap_parser/tokenizer_tests.bzl
+++ b/test/modulemap_parser/tokenizer_tests.bzl
@@ -1,12 +1,24 @@
-load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//spm/internal/modulemap_parser:tokenizer.bzl", "tokenizer")
+load("//spm/internal/modulemap_parser:tokens.bzl", "tokens")
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 
 def _tokenize_test(ctx):
     env = unittest.begin(ctx)
 
-    unittest.fail(env, "IMPLEMENT ME!")
     text = " \t"
     asserts.equals(env, tokenizer.result([]), tokenizer.tokenize(text))
+
+    text = "{}[]!,."
+    expected = tokenizer.result([
+        tokens.curly_bracket_open(),
+        tokens.curly_bracket_close(),
+        tokens.square_bracket_open(),
+        tokens.square_bracket_close(),
+        tokens.exclamation_point(),
+        tokens.comma(),
+        tokens.period(),
+    ])
+    asserts.equals(env, expected, tokenizer.tokenize(text))
 
     return unittest.end(env)
 

--- a/test/modulemap_parser/tokenizer_tests.bzl
+++ b/test/modulemap_parser/tokenizer_tests.bzl
@@ -1,9 +1,12 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//spm/internal/modulemap_parser:tokenizer.bzl", "tokenizer")
 
 def _tokenize_test(ctx):
     env = unittest.begin(ctx)
 
     unittest.fail(env, "IMPLEMENT ME!")
+    text = " \t"
+    asserts.equals(env, tokenizer.result([]), tokenizer.tokenize(text))
 
     return unittest.end(env)
 

--- a/test/modulemap_parser/tokenizer_tests.bzl
+++ b/test/modulemap_parser/tokenizer_tests.bzl
@@ -68,6 +68,18 @@ def _tokenize_test(ctx):
     result = tokenizer.tokenize(text)
     asserts.equals(env, expected, result, "consume string literals")
 
+    text = "1234 0x3 02 12.34"
+    expected = tokenizer.result(
+        tokens = [
+            tokens.integer_literal(1234),
+            tokens.integer_literal(0x3),
+            tokens.integer_literal(0o2),
+            tokens.float_literal(12.34),
+        ],
+    )
+    result = tokenizer.tokenize(text)
+    asserts.equals(env, expected, result, "consume string literals")
+
     return unittest.end(env)
 
 tokenize_test = unittest.make(_tokenize_test)

--- a/test/modulemap_parser/tokenizer_tests.bzl
+++ b/test/modulemap_parser/tokenizer_tests.bzl
@@ -47,6 +47,16 @@ def _tokenize_test(ctx):
     result = tokenizer.tokenize(text)
     asserts.equals(env, expected, result, "consume a single new line")
 
+    text = "a1234 module"
+    expected = tokenizer.result(
+        tokens = [
+            tokens.identifier("a1234"),
+            tokens.reserved("module"),
+        ],
+    )
+    result = tokenizer.tokenize(text)
+    asserts.equals(env, expected, result, "consume identifiers and reserved words")
+
     return unittest.end(env)
 
 tokenize_test = unittest.make(_tokenize_test)

--- a/test/modulemap_parser/tokenizer_tests.bzl
+++ b/test/modulemap_parser/tokenizer_tests.bzl
@@ -6,18 +6,25 @@ def _tokenize_test(ctx):
     env = unittest.begin(ctx)
 
     text = " \t"
-    asserts.equals(env, tokenizer.result([]), tokenizer.tokenize(text))
+    expected = tokenizer.result(
+        tokens = [],
+        consumed_count = len(text),
+    )
+    asserts.equals(env, expected, tokenizer.tokenize(text))
 
     text = "{}[]!,."
-    expected = tokenizer.result([
-        tokens.curly_bracket_open(),
-        tokens.curly_bracket_close(),
-        tokens.square_bracket_open(),
-        tokens.square_bracket_close(),
-        tokens.exclamation_point(),
-        tokens.comma(),
-        tokens.period(),
-    ])
+    expected = tokenizer.result(
+        tokens = [
+            tokens.curly_bracket_open(),
+            tokens.curly_bracket_close(),
+            tokens.square_bracket_open(),
+            tokens.square_bracket_close(),
+            tokens.exclamation_point(),
+            tokens.comma(),
+            tokens.period(),
+        ],
+        consumed_count = len(text),
+    )
     asserts.equals(env, expected, tokenizer.tokenize(text))
 
     return unittest.end(env)

--- a/test/modulemap_parser/tokenizer_tests.bzl
+++ b/test/modulemap_parser/tokenizer_tests.bzl
@@ -1,0 +1,16 @@
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+
+def _tokenize_test(ctx):
+    env = unittest.begin(ctx)
+
+    unittest.fail(env, "IMPLEMENT ME!")
+
+    return unittest.end(env)
+
+tokenize_test = unittest.make(_tokenize_test)
+
+def tokenizer_test_suite():
+    return unittest.suite(
+        "tokenizer_tests",
+        tokenize_test,
+    )

--- a/test/modulemap_parser/tokenizer_tests.bzl
+++ b/test/modulemap_parser/tokenizer_tests.bzl
@@ -8,7 +8,6 @@ def _tokenize_test(ctx):
     text = " \t"
     expected = tokenizer.result(
         tokens = [],
-        consumed_count = len(text),
     )
     asserts.equals(env, expected, tokenizer.tokenize(text), "consume whitespace")
 
@@ -23,7 +22,6 @@ def _tokenize_test(ctx):
             tokens.comma(),
             tokens.period(),
         ],
-        consumed_count = len(text),
     )
     asserts.equals(env, expected, tokenizer.tokenize(text), "consume no value tokens")
 
@@ -31,10 +29,9 @@ def _tokenize_test(ctx):
     expected = tokenizer.result(
         tokens = [
             tokens.curly_bracket_open(),
-            tokens.newLine(),
+            tokens.newline(),
             tokens.curly_bracket_close(),
         ],
-        consumed_count = len(text),
     )
     result = tokenizer.tokenize(text)
     asserts.equals(env, expected, result, "consume multiple new lines")
@@ -43,10 +40,9 @@ def _tokenize_test(ctx):
     expected = tokenizer.result(
         tokens = [
             tokens.curly_bracket_open(),
-            tokens.newLine(),
+            tokens.newline(),
             tokens.curly_bracket_close(),
         ],
-        consumed_count = len(text),
     )
     result = tokenizer.tokenize(text)
     asserts.equals(env, expected, result, "consume a single new line")

--- a/test/modulemap_parser/tokenizer_tests.bzl
+++ b/test/modulemap_parser/tokenizer_tests.bzl
@@ -57,6 +57,17 @@ def _tokenize_test(ctx):
     result = tokenizer.tokenize(text)
     asserts.equals(env, expected, result, "consume identifiers and reserved words")
 
+    text = "{ \"Hello, World!\" }"
+    expected = tokenizer.result(
+        tokens = [
+            tokens.curly_bracket_open(),
+            tokens.string_literal("Hello, World!"),
+            tokens.curly_bracket_close(),
+        ],
+    )
+    result = tokenizer.tokenize(text)
+    asserts.equals(env, expected, result, "consume string literals")
+
     return unittest.end(env)
 
 tokenize_test = unittest.make(_tokenize_test)

--- a/test/modulemap_parser/tokenizer_tests.bzl
+++ b/test/modulemap_parser/tokenizer_tests.bzl
@@ -10,7 +10,7 @@ def _tokenize_test(ctx):
         tokens = [],
         consumed_count = len(text),
     )
-    asserts.equals(env, expected, tokenizer.tokenize(text))
+    asserts.equals(env, expected, tokenizer.tokenize(text), "consume whitespace")
 
     text = "{}[]!,."
     expected = tokenizer.result(
@@ -25,7 +25,31 @@ def _tokenize_test(ctx):
         ],
         consumed_count = len(text),
     )
-    asserts.equals(env, expected, tokenizer.tokenize(text))
+    asserts.equals(env, expected, tokenizer.tokenize(text), "consume no value tokens")
+
+    text = "{\n\r}"
+    expected = tokenizer.result(
+        tokens = [
+            tokens.curly_bracket_open(),
+            tokens.newLine(),
+            tokens.curly_bracket_close(),
+        ],
+        consumed_count = len(text),
+    )
+    result = tokenizer.tokenize(text)
+    asserts.equals(env, expected, result, "consume multiple new lines")
+
+    text = "{\n}"
+    expected = tokenizer.result(
+        tokens = [
+            tokens.curly_bracket_open(),
+            tokens.newLine(),
+            tokens.curly_bracket_close(),
+        ],
+        consumed_count = len(text),
+    )
+    result = tokenizer.tokenize(text)
+    asserts.equals(env, expected, result, "consume a single new line")
 
     return unittest.end(env)
 

--- a/test/modulemap_parser/tokens_tests.bzl
+++ b/test/modulemap_parser/tokens_tests.bzl
@@ -7,6 +7,22 @@ def _create_token_test(ctx):
     asserts.equals(env, struct(type = tokens.types.identifier, value = "bar"), tokens.identifier("bar"))
     asserts.equals(env, struct(type = tokens.types.comma, value = None), tokens.comma())
 
+    asserts.equals(env, struct(type = tokens.types.reserved, value = "module"), tokens.reserved("module"))
+    asserts.equals(env, struct(type = tokens.types.identifier, value = "a1234"), tokens.identifier("a1234"))
+    asserts.equals(env, struct(type = tokens.types.string_literal, value = "Hello, World!"), tokens.string_literal("Hello, World!"))
+    asserts.equals(env, struct(type = tokens.types.integer_literal, value = 123), tokens.integer_literal(123))
+    asserts.equals(env, struct(type = tokens.types.float_literal, value = 123.45), tokens.float_literal(123.45))
+    asserts.equals(env, struct(type = tokens.types.comment, value = "A helpful comment."), tokens.comment("A helpful comment."))
+    asserts.equals(env, struct(type = tokens.types.operator, value = "*"), tokens.operator("*"))
+    asserts.equals(env, struct(type = tokens.types.curly_bracket_open, value = None), tokens.curly_bracket_open())
+    asserts.equals(env, struct(type = tokens.types.curly_bracket_close, value = None), tokens.curly_bracket_close())
+    asserts.equals(env, struct(type = tokens.types.newLine, value = None), tokens.newLine())
+    asserts.equals(env, struct(type = tokens.types.square_bracket_open, value = None), tokens.square_bracket_open())
+    asserts.equals(env, struct(type = tokens.types.square_bracket_close, value = None), tokens.square_bracket_close())
+    asserts.equals(env, struct(type = tokens.types.exclamation_point, value = None), tokens.exclamation_point())
+    asserts.equals(env, struct(type = tokens.types.comma, value = None), tokens.comma())
+    asserts.equals(env, struct(type = tokens.types.period, value = None), tokens.period())
+
     return unittest.end(env)
 
 create_token_test = unittest.make(_create_token_test)

--- a/test/modulemap_parser/tokens_tests.bzl
+++ b/test/modulemap_parser/tokens_tests.bzl
@@ -27,8 +27,28 @@ def _create_token_test(ctx):
 
 create_token_test = unittest.make(_create_token_test)
 
+def _next_test(ctx):
+    env = unittest.begin(ctx)
+
+    unittest.fail(env, "IMPLEMENT ME!")
+
+    return unittest.end(env)
+
+next_test = unittest.make(_next_test)
+
+def _next_as_test(ctx):
+    env = unittest.begin(ctx)
+
+    unittest.fail(env, "IMPLEMENT ME!")
+
+    return unittest.end(env)
+
+next_as_test = unittest.make(_next_as_test)
+
 def tokens_test_suite():
     return unittest.suite(
         "tokens_tests",
         create_token_test,
+        next_test,
+        next_as_test,
     )

--- a/test/modulemap_parser/tokens_tests.bzl
+++ b/test/modulemap_parser/tokens_tests.bzl
@@ -1,5 +1,6 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//spm/internal/modulemap_parser:tokens.bzl", "tokens")
+load("//spm/internal/modulemap_parser:errors.bzl", "errors")
 
 def _create_token_test(ctx):
     env = unittest.begin(ctx)
@@ -27,28 +28,46 @@ def _create_token_test(ctx):
 
 create_token_test = unittest.make(_create_token_test)
 
-def _next_test(ctx):
+def _get_test(ctx):
+    env = unittest.begin(ctx)
+
+    token_list = [tokens.comma()]
+
+    token, err = tokens.get(token_list, 0)
+    if err:
+        unittest.fail(env, "Error while testing get() %s" % (err))
+    asserts.equals(env, tokens.comma(), token)
+
+    token, err = tokens.get(token_list, 1)
+    asserts.equals(env, err, errors.new("No more tokens available. count: 1, idx: 1"))
+    asserts.equals(env, None, token)
+
+    token, err = tokens.get(token_list, -1)
+    asserts.equals(env, err, errors.new("Negative indices are not supported. idx: -1"))
+    asserts.equals(env, None, token)
+
+    # Make sure that it uses the specified count.
+    token, err = tokens.get(token_list, 0, count = 0)
+    asserts.equals(env, err, errors.new("No more tokens available. count: 0, idx: 0"))
+    asserts.equals(env, None, token)
+
+    return unittest.end(env)
+
+get_test = unittest.make(_get_test)
+
+def _get_as_test(ctx):
     env = unittest.begin(ctx)
 
     unittest.fail(env, "IMPLEMENT ME!")
 
     return unittest.end(env)
 
-next_test = unittest.make(_next_test)
-
-def _next_as_test(ctx):
-    env = unittest.begin(ctx)
-
-    unittest.fail(env, "IMPLEMENT ME!")
-
-    return unittest.end(env)
-
-next_as_test = unittest.make(_next_as_test)
+get_as_test = unittest.make(_get_as_test)
 
 def tokens_test_suite():
     return unittest.suite(
         "tokens_tests",
         create_token_test,
-        next_test,
-        next_as_test,
+        get_test,
+        get_as_test,
     )

--- a/test/modulemap_parser/tokens_tests.bzl
+++ b/test/modulemap_parser/tokens_tests.bzl
@@ -34,21 +34,20 @@ def _get_test(ctx):
     token_list = [tokens.comma()]
 
     token, err = tokens.get(token_list, 0)
-    if err:
-        unittest.fail(env, "Error while testing get() %s" % (err))
+    asserts.equals(env, None, err)
     asserts.equals(env, tokens.comma(), token)
 
     token, err = tokens.get(token_list, 1)
-    asserts.equals(env, err, errors.new("No more tokens available. count: 1, idx: 1"))
+    asserts.equals(env, errors.new("No more tokens available. count: 1, idx: 1"), err)
     asserts.equals(env, None, token)
 
     token, err = tokens.get(token_list, -1)
-    asserts.equals(env, err, errors.new("Negative indices are not supported. idx: -1"))
+    asserts.equals(env, errors.new("Negative indices are not supported. idx: -1"), err)
     asserts.equals(env, None, token)
 
     # Make sure that it uses the specified count.
     token, err = tokens.get(token_list, 0, count = 0)
-    asserts.equals(env, err, errors.new("No more tokens available. count: 0, idx: 0"))
+    asserts.equals(env, errors.new("No more tokens available. count: 0, idx: 0"), err)
     asserts.equals(env, None, token)
 
     return unittest.end(env)
@@ -58,7 +57,23 @@ get_test = unittest.make(_get_test)
 def _get_as_test(ctx):
     env = unittest.begin(ctx)
 
-    unittest.fail(env, "IMPLEMENT ME!")
+    token_list = [tokens.string_literal("Hello")]
+
+    token, err = tokens.get_as(token_list, 0, tokens.types.string_literal)
+    asserts.equals(env, None, err)
+    asserts.equals(env, tokens.string_literal("Hello"), token)
+
+    token, err = tokens.get_as(token_list, 0, tokens.types.string_literal, "Hello")
+    asserts.equals(env, None, err)
+    asserts.equals(env, tokens.string_literal("Hello"), token)
+
+    token, err = tokens.get_as(token_list, 0, tokens.types.comma)
+    asserts.equals(env, errors.new("Expected type comma, but was string_literal"), err)
+    asserts.equals(env, None, token)
+
+    token, err = tokens.get_as(token_list, 0, tokens.types.string_literal, "Goodbye")
+    asserts.equals(env, errors.new("Expected value Goodbye, but was Hello"), err)
+    asserts.equals(env, None, token)
 
     return unittest.end(env)
 

--- a/test/modulemap_parser/tokens_tests.bzl
+++ b/test/modulemap_parser/tokens_tests.bzl
@@ -16,7 +16,7 @@ def _create_token_test(ctx):
     asserts.equals(env, struct(type = tokens.types.operator, value = "*"), tokens.operator("*"))
     asserts.equals(env, struct(type = tokens.types.curly_bracket_open, value = None), tokens.curly_bracket_open())
     asserts.equals(env, struct(type = tokens.types.curly_bracket_close, value = None), tokens.curly_bracket_close())
-    asserts.equals(env, struct(type = tokens.types.newLine, value = None), tokens.newLine())
+    asserts.equals(env, struct(type = tokens.types.newline, value = None), tokens.newline())
     asserts.equals(env, struct(type = tokens.types.square_bracket_open, value = None), tokens.square_bracket_open())
     asserts.equals(env, struct(type = tokens.types.square_bracket_close, value = None), tokens.square_bracket_close())
     asserts.equals(env, struct(type = tokens.types.exclamation_point, value = None), tokens.exclamation_point())

--- a/test/modulemap_parser/tokens_tests.bzl
+++ b/test/modulemap_parser/tokens_tests.bzl
@@ -79,10 +79,24 @@ def _get_as_test(ctx):
 
 get_as_test = unittest.make(_get_as_test)
 
+def _is_a_test(ctx):
+    env = unittest.begin(ctx)
+
+    token = tokens.identifier("foo")
+    asserts.true(env, tokens.is_a(token, tts.identifier))
+    asserts.true(env, tokens.is_a(token, tts.identifier, "foo"))
+    asserts.false(env, tokens.is_a(token, tts.reserved))
+    asserts.false(env, tokens.is_a(token, tts.identifier, "bar"))
+
+    return unittest.end(env)
+
+is_a_test = unittest.make(_is_a_test)
+
 def tokens_test_suite():
     return unittest.suite(
         "tokens_tests",
         create_token_test,
         get_test,
         get_as_test,
+        is_a_test,
     )

--- a/test/modulemap_parser/tokens_tests.bzl
+++ b/test/modulemap_parser/tokens_tests.bzl
@@ -1,28 +1,28 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
-load("//spm/internal/modulemap_parser:tokens.bzl", "tokens")
+load("//spm/internal/modulemap_parser:tokens.bzl", "tokens", tts = "token_types")
 load("//spm/internal/modulemap_parser:errors.bzl", "errors")
 
 def _create_token_test(ctx):
     env = unittest.begin(ctx)
 
-    asserts.equals(env, struct(type = tokens.types.identifier, value = "bar"), tokens.identifier("bar"))
-    asserts.equals(env, struct(type = tokens.types.comma, value = None), tokens.comma())
+    asserts.equals(env, struct(type = tts.identifier, value = "bar"), tokens.identifier("bar"))
+    asserts.equals(env, struct(type = tts.comma, value = None), tokens.comma())
 
-    asserts.equals(env, struct(type = tokens.types.reserved, value = "module"), tokens.reserved("module"))
-    asserts.equals(env, struct(type = tokens.types.identifier, value = "a1234"), tokens.identifier("a1234"))
-    asserts.equals(env, struct(type = tokens.types.string_literal, value = "Hello, World!"), tokens.string_literal("Hello, World!"))
-    asserts.equals(env, struct(type = tokens.types.integer_literal, value = 123), tokens.integer_literal(123))
-    asserts.equals(env, struct(type = tokens.types.float_literal, value = 123.45), tokens.float_literal(123.45))
-    asserts.equals(env, struct(type = tokens.types.comment, value = "A helpful comment."), tokens.comment("A helpful comment."))
-    asserts.equals(env, struct(type = tokens.types.operator, value = "*"), tokens.operator("*"))
-    asserts.equals(env, struct(type = tokens.types.curly_bracket_open, value = None), tokens.curly_bracket_open())
-    asserts.equals(env, struct(type = tokens.types.curly_bracket_close, value = None), tokens.curly_bracket_close())
-    asserts.equals(env, struct(type = tokens.types.newline, value = None), tokens.newline())
-    asserts.equals(env, struct(type = tokens.types.square_bracket_open, value = None), tokens.square_bracket_open())
-    asserts.equals(env, struct(type = tokens.types.square_bracket_close, value = None), tokens.square_bracket_close())
-    asserts.equals(env, struct(type = tokens.types.exclamation_point, value = None), tokens.exclamation_point())
-    asserts.equals(env, struct(type = tokens.types.comma, value = None), tokens.comma())
-    asserts.equals(env, struct(type = tokens.types.period, value = None), tokens.period())
+    asserts.equals(env, struct(type = tts.reserved, value = "module"), tokens.reserved("module"))
+    asserts.equals(env, struct(type = tts.identifier, value = "a1234"), tokens.identifier("a1234"))
+    asserts.equals(env, struct(type = tts.string_literal, value = "Hello, World!"), tokens.string_literal("Hello, World!"))
+    asserts.equals(env, struct(type = tts.integer_literal, value = 123), tokens.integer_literal(123))
+    asserts.equals(env, struct(type = tts.float_literal, value = 123.45), tokens.float_literal(123.45))
+    asserts.equals(env, struct(type = tts.comment, value = "A helpful comment."), tokens.comment("A helpful comment."))
+    asserts.equals(env, struct(type = tts.operator, value = "*"), tokens.operator("*"))
+    asserts.equals(env, struct(type = tts.curly_bracket_open, value = None), tokens.curly_bracket_open())
+    asserts.equals(env, struct(type = tts.curly_bracket_close, value = None), tokens.curly_bracket_close())
+    asserts.equals(env, struct(type = tts.newline, value = None), tokens.newline())
+    asserts.equals(env, struct(type = tts.square_bracket_open, value = None), tokens.square_bracket_open())
+    asserts.equals(env, struct(type = tts.square_bracket_close, value = None), tokens.square_bracket_close())
+    asserts.equals(env, struct(type = tts.exclamation_point, value = None), tokens.exclamation_point())
+    asserts.equals(env, struct(type = tts.comma, value = None), tokens.comma())
+    asserts.equals(env, struct(type = tts.period, value = None), tokens.period())
 
     return unittest.end(env)
 
@@ -59,19 +59,19 @@ def _get_as_test(ctx):
 
     token_list = [tokens.string_literal("Hello")]
 
-    token, err = tokens.get_as(token_list, 0, tokens.types.string_literal)
+    token, err = tokens.get_as(token_list, 0, tts.string_literal)
     asserts.equals(env, None, err)
     asserts.equals(env, tokens.string_literal("Hello"), token)
 
-    token, err = tokens.get_as(token_list, 0, tokens.types.string_literal, "Hello")
+    token, err = tokens.get_as(token_list, 0, tts.string_literal, "Hello")
     asserts.equals(env, None, err)
     asserts.equals(env, tokens.string_literal("Hello"), token)
 
-    token, err = tokens.get_as(token_list, 0, tokens.types.comma)
+    token, err = tokens.get_as(token_list, 0, tts.comma)
     asserts.equals(env, errors.new("Expected type comma, but was string_literal"), err)
     asserts.equals(env, None, token)
 
-    token, err = tokens.get_as(token_list, 0, tokens.types.string_literal, "Goodbye")
+    token, err = tokens.get_as(token_list, 0, tts.string_literal, "Goodbye")
     asserts.equals(env, errors.new("Expected value Goodbye, but was Hello"), err)
     asserts.equals(env, None, token)
 


### PR DESCRIPTION
Related to #19.

Goal: During the loading phase, identify the public headers for clang modules that provide their own `module.modulemap` files so that `BUILD.bazel` files with `objc_library` targets can be generated.

- Implemented a rudimentary tokenizer and parser for modulemap files in Starlark.
- The current implementation supports a subset of the grammar as described [here](https://clang.llvm.org/docs/Modules.html#module-map-language).
  - Supports: top-level modules with header declarations, umbrella directory declarations and export declarations.
  - Does not support: submodules (Starlark does not support recursive function calls. Need to refactor parsing to avoid this.)
 