### PR TITLE
Switch to Skylark json module and update examples to include tests

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -31,16 +31,16 @@ jobs:
       shell: bash
       run: |
         cd examples/simple
-        bazelisk run //:simple
+        bazelisk test //...
 
     - name: Build Simple_C Example
       shell: bash
       run: |
         cd examples/simple_c
-        bazelisk run //:simple_c
+        bazelisk test //...
 
     - name: Build Complex Example
       shell: bash
       run: |
         cd examples/complex
-        bazelisk run //:complex
+        bazelisk test //...

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -31,16 +31,16 @@ jobs:
       shell: bash
       run: |
         cd examples/simple
-        bazelisk build //... 
+        bazelisk run //:simple
 
     - name: Build Simple_C Example
       shell: bash
       run: |
         cd examples/simple_c
-        bazelisk build //... 
+        bazelisk run //:simple_c
 
     - name: Build Complex Example
       shell: bash
       run: |
         cd examples/complex
-        bazelisk build //... 
+        bazelisk run //:complex

--- a/examples/complex/BUILD.bazel
+++ b/examples/complex/BUILD.bazel
@@ -9,3 +9,10 @@ swift_binary(
         "@apple_swift_nio//:NIO",
     ],
 )
+
+sh_test(
+    name = "complex_test",
+    srcs = ["complex_test.sh"],
+    data = [":complex"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)

--- a/examples/complex/complex_test.sh
+++ b/examples/complex/complex_test.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+err_msg() {
+  local msg="$1"
+  echo >&2 "${msg}"
+  exit 1
+}
+
+workspace="complex_example"
+binary="$(rlocation "${workspace}/complex")"
+
+expected="Hello World"
+"${binary}" | grep "${expected}" || err_msg "Failed to find expected output. ${expected}"
+

--- a/examples/simple/BUILD.bazel
+++ b/examples/simple/BUILD.bazel
@@ -8,3 +8,10 @@ swift_binary(
         "@apple_swift_log//:Logging",
     ],
 )
+
+sh_test(
+    name = "simple_test",
+    srcs = ["simple_test.sh"],
+    data = [":simple"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)

--- a/examples/simple/simple_test.sh
+++ b/examples/simple/simple_test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+err_msg() {
+  local msg="$1"
+  echo >&2 "${msg}"
+  exit 1
+}
+
+workspace="simple_example"
+simple_bin="$(rlocation "${workspace}/simple")"
+
+expected="Hello World"
+"${simple_bin}" | grep "${expected}" || err_msg "Failed to find expected output. ${expected}"

--- a/examples/simple_c/BUILD.bazel
+++ b/examples/simple_c/BUILD.bazel
@@ -8,3 +8,10 @@ swift_binary(
         "@apple_swift_nio//:CNIOSHA1",
     ],
 )
+
+sh_test(
+    name = "simple_c_test",
+    srcs = ["simple_c_test.sh"],
+    data = [":simple_c"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)

--- a/examples/simple_c/WORKSPACE
+++ b/examples/simple_c/WORKSPACE
@@ -1,4 +1,4 @@
-workspace(name = "complex_example")
+workspace(name = "simple_c_example")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 

--- a/examples/simple_c/main.swift
+++ b/examples/simple_c/main.swift
@@ -1,6 +1,6 @@
 import CNIOSHA1
 
-var sha1Ctx: SHA1_CTX = SHA1_CTX()
+var sha1Ctx = SHA1_CTX()
 c_nio_sha1_init(&sha1Ctx)
 
-Swift.print("*** CHUCK  sha1Ctx: \(String(reflecting: sha1Ctx))")
+Swift.print("Hello World! \(String(reflecting: sha1Ctx))")

--- a/examples/simple_c/simple_c_test.sh
+++ b/examples/simple_c/simple_c_test.sh
@@ -17,8 +17,9 @@ err_msg() {
   exit 1
 }
 
-workspace="simple_example"
-binary="$(rlocation "${workspace}/simple")"
+workspace="simple_c_example"
+binary="$(rlocation "${workspace}/simple_c")"
 
 expected="Hello World"
 "${binary}" | grep "${expected}" || err_msg "Failed to find expected output. ${expected}"
+

--- a/spm/internal/BUILD.bazel
+++ b/spm/internal/BUILD.bazel
@@ -9,9 +9,6 @@ bzl_library(
     name = "spm_package",
     srcs = ["spm_package.bzl"],
     visibility = ["//spm:__subpackages__"],
-    deps = [
-        "@erickj_bazel_json//lib:json_parser.bzl",
-    ],
 )
 
 bzl_library(

--- a/spm/internal/package_description.bzl
+++ b/spm/internal/package_description.bzl
@@ -1,6 +1,4 @@
-load("@erickj_bazel_json//lib:json_parser.bzl", "json_parse")
-
-def parse_package_description_json(json):
+def parse_package_description_json(json_str):
     """Parses the JSON string and returns a dict representing the JSON structure.
 
     Args:
@@ -9,7 +7,7 @@ def parse_package_description_json(json):
     Returns:
         A dict which contains the information from the JSON string.
     """
-    return json_parse(json)
+    return json.decode(json_str)
 
 def is_library_product(product):
     return "library" in product["type"]

--- a/spm/internal/spm_repository.bzl
+++ b/spm/internal/spm_repository.bzl
@@ -134,10 +134,12 @@ def _spm_repository_impl(ctx):
         stripPrefix = ctx.attr.strip_prefix,
     )
 
-    # Resolve/fetch the dependencies and cache them in the spm_cache directory.
+    # Resolve/fetch the dependencies.
     resolve_result = ctx.execute(["swift", "package", "resolve", "--build-path", "spm_build"])
     if resolve_result.return_code != 0:
         fail("Resolution of SPM packages for %s failed.\n%s" % (ctx.attr.name, resolve_result.stderr))
+
+    # TODO: For each dependency, generate describe JSON and store it in a JSON struct?
 
     # Generate description for the package.
     describe_result = ctx.execute(["swift", "package", "describe", "--type", "json"])

--- a/spm/repositories.bzl
+++ b/spm/repositories.bzl
@@ -12,22 +12,6 @@ def rules_spm_dependencies():
         ],
     )
 
-    # maybe(
-    #     http_archive,
-    #     name = "erickj_bazel_json",
-    #     sha256 = "a57a6f794943548fde6da8ec3edad88af89436e8102f33d8f6135202699847f4",
-    #     urls = ["https://github.com/erickj/bazel_json/archive/e954ef2c28cd92d97304810e8999e1141e2b5cc8.tar.gz"],  # 2019-01-02
-    # )
-
-    # Forked version with updates making it compatible with Bazel 4.1.0 and bazel-skylib 1.0.3.
-    maybe(
-        http_archive,
-        name = "erickj_bazel_json",
-        sha256 = "50ee4730b124e143eab66afdbe2ce077858aba7c996ae9b1acb45927321d2cd3",
-        strip_prefix = "bazel_json-916ead87b0c19ef6b8ff2763ff2a8e8a1072fa52",
-        urls = ["https://github.com/cgrindel/bazel_json/archive/916ead87b0c19ef6b8ff2763ff2a8e8a1072fa52.tar.gz"],  # 2021-07-02
-    )
-
     maybe(
         http_archive,
         name = "build_bazel_rules_swift",


### PR DESCRIPTION
- Removed the third-party json library. Switched to the Skylark `json` module.
- Added tests to all of the examples to confirm that they execute properly.
- Updated the workflow to run the example tests.