### PR TITLE
Updated badge status to take user to the workflow when clicked.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Swift Package Manager Rules for Bazel
 
-![build status](https://github.com/cgrindel/rules_spm/actions/workflows/bazel.yml/badge.svg)
+[![Build](https://github.com/cgrindel/rules_spm/actions/workflows/bazel.yml/badge.svg)](https://github.com/cgrindel/rules_spm/actions/workflows/bazel.yml)
 
 This repository contains rules for [Bazel](https://bazel.build/) that can be used to download, build
 and consume Swift packages with [rules_swift](https://github.com/bazelbuild/rules_swift) rules.  The


### PR DESCRIPTION
Updated to use badge status code from `Create status badge` in the workflow screen.

Closes #25.