### PR TITLE
Support building and using third-party binaries.

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -46,6 +46,12 @@ jobs:
         cd examples/simple_revision
         bazelisk test //...
 
+    - name: Test Simple with External Binary Example
+      shell: bash
+      run: |
+        cd examples/simple_with_binary
+        bazelisk test //...
+
     - name: Test Package With Shared Deps Example
       shell: bash
       run: |

--- a/examples/simple/BUILD.bazel
+++ b/examples/simple/BUILD.bazel
@@ -15,3 +15,8 @@ sh_test(
     data = [":simple"],
     deps = ["@bazel_tools//tools/bash/runfiles"],
 )
+
+alias(
+    name = "swiftlint",
+    actual = "@swift_utils//SwiftLint:swiftlint",
+)

--- a/examples/simple/BUILD.bazel
+++ b/examples/simple/BUILD.bazel
@@ -16,7 +16,7 @@ sh_test(
     deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
-# alias(
-#     name = "swiftlint",
-#     actual = "@swift_utils//SwiftLint:swiftlint",
-# )
+alias(
+    name = "swiftlint",
+    actual = "@swift_utils//SwiftLint:swiftlint",
+)

--- a/examples/simple/BUILD.bazel
+++ b/examples/simple/BUILD.bazel
@@ -15,8 +15,3 @@ sh_test(
     data = [":simple"],
     deps = ["@bazel_tools//tools/bash/runfiles"],
 )
-
-alias(
-    name = "swiftlint",
-    actual = "@swift_utils//SwiftLint:swiftlint",
-)

--- a/examples/simple/BUILD.bazel
+++ b/examples/simple/BUILD.bazel
@@ -16,7 +16,7 @@ sh_test(
     deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
-alias(
-    name = "swiftlint",
-    actual = "@swift_utils//SwiftLint:swiftlint",
-)
+# alias(
+#     name = "swiftlint",
+#     actual = "@swift_utils//SwiftLint:swiftlint",
+# )

--- a/examples/simple/WORKSPACE
+++ b/examples/simple/WORKSPACE
@@ -38,5 +38,10 @@ spm_repositories(
             from_version = "1.0.0",
             products = ["Logging"],
         ),
+        spm_pkg(
+            "https://github.com/realm/SwiftLint.git",
+            from_version = "0.0.0",
+            products = ["swiftlint"],
+        ),
     ],
 )

--- a/examples/simple/WORKSPACE
+++ b/examples/simple/WORKSPACE
@@ -41,16 +41,16 @@ spm_repositories(
     ],
 )
 
-# spm_repositories(
-#     name = "swift_utils",
-#     dependencies = [
-#         spm_pkg(
-#             "https://github.com/realm/SwiftLint.git",
-#             from_version = "0.0.0",
-#             products = ["swiftlint"],
-#         ),
-#     ],
-#     platforms = [
-#         ".macOS(.v10_12)",
-#     ],
-# )
+spm_repositories(
+    name = "swift_utils",
+    dependencies = [
+        spm_pkg(
+            "https://github.com/realm/SwiftLint.git",
+            from_version = "0.0.0",
+            products = ["swiftlint"],
+        ),
+    ],
+    platforms = [
+        ".macOS(.v10_12)",
+    ],
+)

--- a/examples/simple/WORKSPACE
+++ b/examples/simple/WORKSPACE
@@ -38,10 +38,19 @@ spm_repositories(
             from_version = "1.0.0",
             products = ["Logging"],
         ),
+    ],
+)
+
+spm_repositories(
+    name = "swift_utils",
+    dependencies = [
         spm_pkg(
             "https://github.com/realm/SwiftLint.git",
             from_version = "0.0.0",
             products = ["swiftlint"],
         ),
+    ],
+    platforms = [
+        ".macOS(.v10_12)",
     ],
 )

--- a/examples/simple/WORKSPACE
+++ b/examples/simple/WORKSPACE
@@ -41,16 +41,16 @@ spm_repositories(
     ],
 )
 
-spm_repositories(
-    name = "swift_utils",
-    dependencies = [
-        spm_pkg(
-            "https://github.com/realm/SwiftLint.git",
-            from_version = "0.0.0",
-            products = ["swiftlint"],
-        ),
-    ],
-    platforms = [
-        ".macOS(.v10_12)",
-    ],
-)
+# spm_repositories(
+#     name = "swift_utils",
+#     dependencies = [
+#         spm_pkg(
+#             "https://github.com/realm/SwiftLint.git",
+#             from_version = "0.0.0",
+#             products = ["swiftlint"],
+#         ),
+#     ],
+#     platforms = [
+#         ".macOS(.v10_12)",
+#     ],
+# )

--- a/examples/simple/WORKSPACE
+++ b/examples/simple/WORKSPACE
@@ -40,17 +40,3 @@ spm_repositories(
         ),
     ],
 )
-
-spm_repositories(
-    name = "swift_utils",
-    dependencies = [
-        spm_pkg(
-            "https://github.com/realm/SwiftLint.git",
-            from_version = "0.0.0",
-            products = ["swiftlint"],
-        ),
-    ],
-    platforms = [
-        ".macOS(.v10_12)",
-    ],
-)

--- a/examples/simple_with_binary/.bazelrc
+++ b/examples/simple_with_binary/.bazelrc
@@ -1,0 +1,8 @@
+# Import Shared settings
+import %workspace%/../../shared.bazelrc
+
+# Import CI settings.
+import %workspace%/../../ci.bazelrc
+
+# Try to import a local.rc file; typically, written by CI
+try-import %workspace%/../../local.bazelrc

--- a/examples/simple_with_binary/BUILD.bazel
+++ b/examples/simple_with_binary/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary")
+
+swift_binary(
+    name = "simple_with_binary",
+    srcs = ["main.swift"],
+    visibility = ["//swift:__subpackages__"],
+    deps = [
+        "@swift_pkgs//swift-log:Logging",
+    ],
+)
+
+sh_test(
+    name = "simple_with_binary_test",
+    srcs = ["simple_with_binary_test.sh"],
+    data = [":simple_with_binary"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)
+
+# Make sure that the binary is referenced. Otherwise, Bazel won't build it.
+alias(
+    name = "swiftlint",
+    actual = "@swift_utils//SwiftLint:swiftlint",
+)

--- a/examples/simple_with_binary/BUILD.bazel
+++ b/examples/simple_with_binary/BUILD.bazel
@@ -21,3 +21,12 @@ alias(
     name = "swiftlint",
     actual = "@swift_utils//SwiftLint:swiftlint",
 )
+
+sh_test(
+    name = "swiftlint_test",
+    srcs = ["swiftlint_test.sh"],
+    data = [
+        ":swiftlint",
+    ],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)

--- a/examples/simple_with_binary/README.md
+++ b/examples/simple_with_binary/README.md
@@ -1,0 +1,5 @@
+# Simple Example for `rules_spm`
+
+This example demonstrates how to use executables defined in third-party packages.
+
+TODO: Add discussion about the use of multiple spm_repositories.

--- a/examples/simple_with_binary/README.md
+++ b/examples/simple_with_binary/README.md
@@ -1,5 +1,77 @@
 # Simple Example for `rules_spm`
 
-This example demonstrates how to use executables defined in third-party packages.
+This example demonstrates how to use executables defined in third-party packages. Typically, these
+binaries are used to maintain the project.
 
-TODO: Add discussion about the use of multiple spm_repositories.
+## Quick Start
+
+Add an `spm_repositories` declaration for the external binaries.
+
+```python
+# These are packages that are dependencies for the project
+spm_repositories(
+    name = "swift_pkgs",
+    dependencies = [
+        spm_pkg(
+            "https://github.com/apple/swift-log.git",
+            from_version = "1.0.0",
+            products = ["Logging"],
+        ),
+    ],
+)
+
+# Thes are packages that have binaries that are useful to the project.
+spm_repositories(
+    name = "swift_utils",
+    dependencies = [
+        spm_pkg(
+            "https://github.com/realm/SwiftLint.git",
+            from_version = "0.0.0",
+            products = ["swiftlint"],
+        ),
+    ],
+    platforms = [
+        ".macOS(.v10_12)",
+    ],
+)
+
+```
+
+Add a reference to the binary that you want to use. In this case, we will create an alias in the
+root of the project.
+
+```python
+# Make sure that the binary is referenced. Otherwise, Bazel won't build it.
+alias(
+    name = "swiftlint",
+    actual = "@swift_utils//SwiftLint:swiftlint",
+)
+```
+
+Use the binary. In this example, we will run `swiftlint` on the Swift files in the current
+directory. NOTE: The `$(pwd)` magic is related to how Bazel executes binaries using `bazel run`.
+
+```sh
+$ bazel run //:swiftlint -- lint $(pwd)
+INFO: Analyzed target //:swiftlint (0 packages loaded, 0 targets configured).
+INFO: Found 1 target...
+Target @swift_utils//SwiftLint:swiftlint up-to-date:
+  bazel-bin/external/swift_utils/SwiftLint/swiftlint
+INFO: Elapsed time: 0.243s, Critical Path: 0.07s
+INFO: 1 process: 1 internal.
+INFO: Build completed successfully, 1 total action
+INFO: Build completed successfully, 1 total action
+Linting Swift files at paths /Users/chuck/code/cgrindel/rules_spm/examples/simple_with_binary
+Linting 'main.swift' (1/1)
+Done linting! Found 0 violations, 0 serious in 1 file.
+```
+
+## FAQ
+
+### Can I add the binary packages to the same `spm_repositories` declaration as my dependencies?
+
+Yes. However, you probably don't want to do so. The platform requirements for the binaries may be
+more restrictive then those for your dependencies. In the above example, `swiftlint` requires that
+the underlying SPM build require `.macOS(.v10_12)` or later. This may not be acceptable for your
+final project.
+

--- a/examples/simple_with_binary/WORKSPACE
+++ b/examples/simple_with_binary/WORKSPACE
@@ -1,0 +1,62 @@
+workspace(name = "simple_with_binary_example")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+local_repository(
+    name = "cgrindel_rules_spm",
+    path = "../..",
+)
+
+load(
+    "@cgrindel_rules_spm//spm:deps.bzl",
+    "spm_rules_dependencies",
+)
+
+spm_rules_dependencies()
+
+load(
+    "@build_bazel_rules_swift//swift:repositories.bzl",
+    "swift_rules_dependencies",
+)
+
+swift_rules_dependencies()
+
+load(
+    "@build_bazel_rules_swift//swift:extras.bzl",
+    "swift_rules_extra_dependencies",
+)
+
+swift_rules_extra_dependencies()
+
+load("@cgrindel_rules_spm//spm:spm.bzl", "spm_pkg", "spm_repositories")
+
+# This set of packages are used as dependencies for the project.
+spm_repositories(
+    name = "swift_pkgs",
+    dependencies = [
+        spm_pkg(
+            "https://github.com/apple/swift-log.git",
+            from_version = "1.0.0",
+            products = ["Logging"],
+        ),
+    ],
+)
+
+# This set of packages provide binaries that are helpful for maintaining the
+# project. While these packages could have neen declared in `swift_pkgs`, it
+# would have required that we add a platform restriction to our project
+# dependencies, which may be undesirable. Declaring them in a separate
+# `spm_repositories` avoids this complication.
+spm_repositories(
+    name = "swift_utils",
+    dependencies = [
+        spm_pkg(
+            "https://github.com/realm/SwiftLint.git",
+            from_version = "0.0.0",
+            products = ["swiftlint"],
+        ),
+    ],
+    platforms = [
+        ".macOS(.v10_12)",
+    ],
+)

--- a/examples/simple_with_binary/main.swift
+++ b/examples/simple_with_binary/main.swift
@@ -1,0 +1,4 @@
+import Logging
+
+let logger = Logger(label: "com.example.main")
+logger.info("Hello World!")

--- a/examples/simple_with_binary/simple_with_binary_test.sh
+++ b/examples/simple_with_binary/simple_with_binary_test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+err_msg() {
+  local msg="$1"
+  echo >&2 "${msg}"
+  exit 1
+}
+
+workspace="simple_with_binary_example"
+binary="$(rlocation "${workspace}/simple_with_binary")"
+
+expected="Hello World"
+"${binary}" | grep "${expected}" || err_msg "Failed to find expected output. ${expected}"

--- a/examples/simple_with_binary/swiftlint_test.sh
+++ b/examples/simple_with_binary/swiftlint_test.sh
@@ -11,12 +11,6 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
-err_msg() {
-  local msg="$1"
-  echo >&2 "${msg}"
-  exit 1
-}
-
 swiftlint="$(rlocation "swift_utils/SwiftLint/swiftlint")"
 
 # NOTE: An `illegal instruction: 4` error occurs when we attempt to lint inside of this test. All

--- a/examples/simple_with_binary/swiftlint_test.sh
+++ b/examples/simple_with_binary/swiftlint_test.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+err_msg() {
+  local msg="$1"
+  echo >&2 "${msg}"
+  exit 1
+}
+
+swiftlint="$(rlocation "swift_utils/SwiftLint/swiftlint")"
+
+# NOTE: An `illegal instruction: 4` error occurs when we attempt to lint inside of this test. All
+# seems well when it is executed without linting.
+
+# Make sure that we can execute swiftlint.
+"${swiftlint}" version

--- a/spm/internal/package_descriptions.bzl
+++ b/spm/internal/package_descriptions.bzl
@@ -10,7 +10,7 @@ load(":references.bzl", ref_types = "reference_types", refs = "references")
 
 # MARK: - Helper Functions
 
-def _find_in_list_of_dicts(items, key, value, item_type = None):
+def _find_in_list_of_dicts(items, key, value, item_type = None, fail_if_not_found = True):
     """Retrieves the dict value from a list of items that have a specified
     key value.
 
@@ -21,6 +21,9 @@ def _find_in_list_of_dicts(items, key, value, item_type = None):
     for item in items:
         if item[key] == value:
             return item
+
+    if not fail_if_not_found:
+        return None
 
     if item_type == None:
         item_type = "item"
@@ -151,7 +154,7 @@ def _library_products(pkg_desc):
     """
     return [p for p in pkg_desc["products"] if _is_library_product(p)]
 
-def _get_product(pkg_desc, product_name):
+def _get_product(pkg_desc, product_name, fail_if_not_found = True):
     """Returns the product with the specified product name.
 
     Args:
@@ -161,7 +164,7 @@ def _get_product(pkg_desc, product_name):
     Returns:
         A `dict` representing the desired product.
     """
-    return _find_in_list_of_dicts(pkg_desc["products"], "name", product_name)
+    return _find_in_list_of_dicts(pkg_desc["products"], "name", product_name, fail_if_not_found = fail_if_not_found)
 
 # MARK: - Target Functions
 
@@ -224,7 +227,7 @@ def _is_swift_module(target):
     """
     return target["module_type"] == module_types.swift
 
-def _get_target(pkg_desc, name):
+def _get_target(pkg_desc, name, fail_if_not_found = True):
     """Returns the target with the specified name from a package description.
 
     Args:
@@ -234,7 +237,7 @@ def _get_target(pkg_desc, name):
     Returns:
         A `dict` representing a target as represented in a package description.
     """
-    return _find_in_list_of_dicts(pkg_desc["targets"], "name", name)
+    return _find_in_list_of_dicts(pkg_desc["targets"], "name", name, fail_if_not_found = fail_if_not_found)
 
 # MARK: - Package Dependency Functions
 
@@ -304,9 +307,36 @@ def _gather_deps_for_target(pkg_descs_dict, target_ref):
             continue
         by_name_values = dep.get("byName")
         if by_name_values != None:
-            dep_target_ref = refs.create_target_ref(pkg_name, by_name_values)
-            target_refs.append(dep_target_ref)
-            continue
+            # byName references
+            # Tool Version < 5.2: can be product with the name from any package.
+            # Tool Version >= 5.2: must be a product in a package with the same name.
+            by_name = by_name_values[0]
+
+            # Look for the product in a package with the same name.
+            ref_pkg_desc = pkg_descs_dict.get(by_name)
+            if ref_pkg_desc != None:
+                # product_refs.append(refs.create_product_ref([by_name, ref_pkg_desc["name"], None]))
+                product_refs.append(refs.create(ref_types.product, ref_pkg_desc["name"], by_name))
+                continue
+
+            ref_pkg_desc = _find_pkg_desc_by_product(pkg_descs_dict, by_name)
+            if ref_pkg_desc != None:
+                # product_refs.append(refs.create_product_ref([by_name, ref_pkg_desc["name"], None]))
+                product_refs.append(refs.create(ref_types.product, ref_pkg_desc["name"], by_name))
+                continue
+
+            ref_pkg_desc = _find_pkg_desc_by_target(pkg_descs_dict, by_name)
+            if ref_pkg_desc != None:
+                target_refs.append(refs.create(ref_types.target, ref_pkg_desc["name"], by_name))
+                continue
+
+            fail("byName Resolution: Could not find a package with the product or target named %s." % (by_name))
+
+            # if ref_pkg_desc == None:
+            #     fail("byName Resolution: Could not find a package name %s. Only support >=5.2 byName resolution." % (by_name))
+            # product_refs.append(refs.create_product_ref([by_name, by_name, None]))
+            # continue
+
         target_values = dep.get("target")
         if target_values != None:
             dep_target_ref = refs.create_target_ref(pkg_name, target_values)
@@ -317,7 +347,7 @@ def _gather_deps_for_target(pkg_descs_dict, target_ref):
     return product_refs, target_refs
 
 def _get_product_target_refs(pkg_descs_dict, product_ref):
-    """Returns the target refernces that are directly associated with the 
+    """Returns the target references that are directly associated with the 
     specified product.
 
     Args:
@@ -330,7 +360,7 @@ def _get_product_target_refs(pkg_descs_dict, product_ref):
     Returns:
         A `list` of target reference `string` values.
     """
-    ref_typ, pkg_name, product_name = refs.split(product_ref)
+    ref_type, pkg_name, product_name = refs.split(product_ref)
     pkg_desc = pkg_descs_dict[pkg_name]
     product = _get_product(pkg_desc, product_name)
     return [refs.create(ref_types.target, pkg_name, t) for t in product["targets"]]
@@ -365,6 +395,7 @@ def _transitive_dependencies(pkg_descs_dict, product_refs):
         # Collect the targets that are referenced by the products
         for product_ref in product_refs_to_eval:
             prd_target_refs = _get_product_target_refs(pkg_descs_dict, product_ref)
+
             product_deps_dict[product_ref] = prd_target_refs
             for target_ref in prd_target_refs:
                 if target_deps_dict.get(target_ref) == None:
@@ -378,6 +409,13 @@ def _transitive_dependencies(pkg_descs_dict, product_refs):
             if target_deps_dict.get(target_ref) != None:
                 continue
             dep_prd_refs, dep_trgt_refs = _gather_deps_for_target(pkg_descs_dict, target_ref)
+
+            # DEBUG BEGIN
+            print("*** CHUCK target_ref: ", target_ref)
+            print("*** CHUCK dep_prd_refs: ", dep_prd_refs)
+            print("*** CHUCK dep_trgt_refs: ", dep_trgt_refs)
+
+            # DEBUG END
             target_deps_dict[target_ref] = dep_trgt_refs + dep_prd_refs
             for product_ref in dep_prd_refs:
                 # If we have not resolved the product_ref, add it to the list for evaluation
@@ -409,6 +447,46 @@ def _transitive_dependencies(pkg_descs_dict, product_refs):
         resolved_targets_dict[target_ref] = sorted(resolved_deps)
 
     return resolved_targets_dict
+
+def _find_pkg_desc_by_product(pkg_descs_dict, product_name):
+    """Find the package description which has a product with the specified 
+    name.
+
+    Args:
+        pkg_descs_dict: A `dict` where the keys are the package names and the
+                        values are package description `struct` values as
+                        returned by `package_descriptions.get()`.
+        product_name: The name of a product as a `string`.
+
+    Returns:
+        Returns the package description that has the product or None.
+    """
+    for pkg_name in pkg_descs_dict:
+        pkg_desc = pkg_descs_dict[pkg_name]
+        product = _get_product(pkg_desc, product_name, fail_if_not_found = False)
+        if product != None:
+            return pkg_desc
+    return None
+
+def _find_pkg_desc_by_target(pkg_descs_dict, target_name):
+    """Find the package description which has a target with the specified 
+    name.
+
+    Args:
+        pkg_descs_dict: A `dict` where the keys are the package names and the
+                        values are package description `struct` values as
+                        returned by `package_descriptions.get()`.
+        target_name: The name of a target as a `string`.
+
+    Returns:
+        Returns the package description that has the target or None.
+    """
+    for pkg_name in pkg_descs_dict:
+        pkg_desc = pkg_descs_dict[pkg_name]
+        target = _get_target(pkg_desc, target_name, fail_if_not_found = False)
+        if target != None:
+            return pkg_desc
+    return None
 
 # MARK: - Namespace
 

--- a/spm/internal/package_descriptions.bzl
+++ b/spm/internal/package_descriptions.bzl
@@ -177,8 +177,18 @@ def _is_library_target(target):
     Returns:
         A boolean indicating whether the target is a library target.
     """
-    target_type = target["type"]
-    return target_type == target_types.library
+    return target["type"] == target_types.library
+
+def _is_executable_target(target):
+    """Returns True if the specified target is an executable target. Otherwise False.
+
+    Args:
+        target: A target from the package description.
+
+    Returns:
+        A boolean indicating whether the target is an executable target.
+    """
+    return target["type"] == target_types.executable
 
 def _library_targets(pkg_desc):
     """Returns a list of the library targets in the package.
@@ -192,7 +202,7 @@ def _library_targets(pkg_desc):
     targets = pkg_desc["targets"]
     return [t for t in targets if _is_library_target(t)]
 
-def _is_system_library_module(target):
+def _is_system_library_target(target):
     """Returns True if the specified target is a clang module. Otherwise, False.
 
     Args:
@@ -204,7 +214,7 @@ def _is_system_library_module(target):
     module_type = target["module_type"]
     return module_type == module_types.system_library
 
-def _is_clang_module(target):
+def _is_clang_target(target):
     """Returns True if the specified target is a clang module. Otherwise, False.
 
     Args:
@@ -216,7 +226,7 @@ def _is_clang_module(target):
     module_type = target["module_type"]
     return module_type == module_types.clang
 
-def _is_swift_module(target):
+def _is_swift_target(target):
     """Returns True if the specified target is a swift module. Otherwise, False.
 
     Args:
@@ -480,6 +490,7 @@ def _find_pkg_desc_by_target(pkg_descs_dict, target_name):
 # MARK: - Namespace
 
 target_types = struct(
+    executable = "executable",
     library = "library",
     system = "system-target",
 )
@@ -498,10 +509,11 @@ package_descriptions = struct(
     library_products = _library_products,
     # Target Functions
     is_library_target = _is_library_target,
+    is_executable_target = _is_executable_target,
     library_targets = _library_targets,
-    is_system_library_module = _is_system_library_module,
-    is_clang_module = _is_clang_module,
-    is_swift_module = _is_swift_module,
+    is_system_library_target = _is_system_library_target,
+    is_clang_target = _is_clang_target,
+    is_swift_target = _is_swift_target,
     get_target = _get_target,
     # Dependency Functions
     dependency_name = _dependency_name,

--- a/spm/internal/package_descriptions.bzl
+++ b/spm/internal/package_descriptions.bzl
@@ -315,13 +315,11 @@ def _gather_deps_for_target(pkg_descs_dict, target_ref):
             # Look for the product in a package with the same name.
             ref_pkg_desc = pkg_descs_dict.get(by_name)
             if ref_pkg_desc != None:
-                # product_refs.append(refs.create_product_ref([by_name, ref_pkg_desc["name"], None]))
                 product_refs.append(refs.create(ref_types.product, ref_pkg_desc["name"], by_name))
                 continue
 
             ref_pkg_desc = _find_pkg_desc_by_product(pkg_descs_dict, by_name)
             if ref_pkg_desc != None:
-                # product_refs.append(refs.create_product_ref([by_name, ref_pkg_desc["name"], None]))
                 product_refs.append(refs.create(ref_types.product, ref_pkg_desc["name"], by_name))
                 continue
 
@@ -331,11 +329,6 @@ def _gather_deps_for_target(pkg_descs_dict, target_ref):
                 continue
 
             fail("byName Resolution: Could not find a package with the product or target named %s." % (by_name))
-
-            # if ref_pkg_desc == None:
-            #     fail("byName Resolution: Could not find a package name %s. Only support >=5.2 byName resolution." % (by_name))
-            # product_refs.append(refs.create_product_ref([by_name, by_name, None]))
-            # continue
 
         target_values = dep.get("target")
         if target_values != None:
@@ -410,12 +403,6 @@ def _transitive_dependencies(pkg_descs_dict, product_refs):
                 continue
             dep_prd_refs, dep_trgt_refs = _gather_deps_for_target(pkg_descs_dict, target_ref)
 
-            # DEBUG BEGIN
-            print("*** CHUCK target_ref: ", target_ref)
-            print("*** CHUCK dep_prd_refs: ", dep_prd_refs)
-            print("*** CHUCK dep_trgt_refs: ", dep_trgt_refs)
-
-            # DEBUG END
             target_deps_dict[target_ref] = dep_trgt_refs + dep_prd_refs
             for product_ref in dep_prd_refs:
                 # If we have not resolved the product_ref, add it to the list for evaluation

--- a/spm/internal/package_descriptions.bzl
+++ b/spm/internal/package_descriptions.bzl
@@ -318,11 +318,13 @@ def _gather_deps_for_target(pkg_descs_dict, target_ref):
                 product_refs.append(refs.create(ref_types.product, ref_pkg_desc["name"], by_name))
                 continue
 
+            # Look for a package that has a product with the name
             ref_pkg_desc = _find_pkg_desc_by_product(pkg_descs_dict, by_name)
             if ref_pkg_desc != None:
                 product_refs.append(refs.create(ref_types.product, ref_pkg_desc["name"], by_name))
                 continue
 
+            # Look for a package that has a target with the name
             ref_pkg_desc = _find_pkg_desc_by_target(pkg_descs_dict, by_name)
             if ref_pkg_desc != None:
                 target_refs.append(refs.create(ref_types.target, ref_pkg_desc["name"], by_name))

--- a/spm/internal/package_descriptions.bzl
+++ b/spm/internal/package_descriptions.bzl
@@ -190,6 +190,17 @@ def _is_executable_target(target):
     """
     return target["type"] == target_types.executable
 
+def _is_system_target(target):
+    """Returns True if the specified target is a library target. Otherwise False.
+
+    Args:
+        target: A target from the package description.
+
+    Returns:
+        A boolean indicating whether the target is a library target.
+    """
+    return target["type"] == target_types.system
+
 def _library_targets(pkg_desc):
     """Returns a list of the library targets in the package.
 
@@ -510,6 +521,7 @@ package_descriptions = struct(
     # Target Functions
     is_library_target = _is_library_target,
     is_executable_target = _is_executable_target,
+    is_system_target = _is_system_target,
     library_targets = _library_targets,
     is_system_library_target = _is_system_library_target,
     is_clang_target = _is_clang_target,

--- a/spm/internal/providers.bzl
+++ b/spm/internal/providers.bzl
@@ -72,7 +72,12 @@ def _create_swift_module(
         executable = executable,
     )
 
-def _create_clang_module(module_name, o_files, hdrs, modulemap, all_outputs):
+def _create_clang_module(
+        module_name,
+        o_files = [],
+        hdrs = [],
+        modulemap = None,
+        all_outputs = []):
     """Creates a value representing the Clang module that is built from a package.
 
     Args:
@@ -92,7 +97,12 @@ def _create_clang_module(module_name, o_files, hdrs, modulemap, all_outputs):
         all_outputs = all_outputs,
     )
 
-def _create_system_library_module(module_name, c_files, hdrs, modulemap, all_outputs):
+def _create_system_library_module(
+        module_name,
+        c_files = [],
+        hdrs = [],
+        modulemap = None,
+        all_outputs = []):
     """Creates a value representing the system library module that is built from a package.
 
     Args:

--- a/spm/internal/providers.bzl
+++ b/spm/internal/providers.bzl
@@ -7,7 +7,7 @@ SPMBuildInfo = provider(
         "sdk_name": "A string representing the name of the SDK",
         "target_triple": "A string representing the target platform as a triple.",
         "spm_platform_info": "An `SpmPlatformInfo` describing the target platform.",
-        "swift_executable": "The path for the `swift` executable."
+        "swift_executable": "The path for the `swift` executable.",
     },
 )
 
@@ -17,7 +17,7 @@ SPMPlatformInfo = provider(
         "os": "The OS designation as understood by SPM.",
         "arch": "The architecture designation as understood by SPM.",
         "vendor": "The vendor designation as understood by SPM.",
-        "abi": "The abi destination as understood by SPM."
+        "abi": "The abi destination as understood by SPM.",
     },
 )
 
@@ -40,7 +40,14 @@ SPMPackageInfo = provider(
     },
 )
 
-def _create_swift_module(module_name, o_files, swiftdoc, swiftmodule, swiftsourceinfo, all_outputs):
+def _create_swift_module(
+        module_name,
+        o_files = [],
+        swiftdoc = None,
+        swiftmodule = None,
+        swiftsourceinfo = None,
+        executable = None,
+        all_outputs = []):
     """Creates a value representing the Swift module that is built from a package.
 
     Args:
@@ -49,6 +56,7 @@ def _create_swift_module(module_name, o_files, swiftdoc, swiftmodule, swiftsourc
         swiftdoc: The .swiftdoc file that is built by SPM.
         swiftmodule: The .swiftmodule file that is built by SPM.
         swiftsourceinfo: The .swiftsourceinfo file that is built by SPM.
+        executable: The executable if the target is executable.
         all_outputs: All of the output files that are declared for the module.
 
     Returns:
@@ -61,6 +69,7 @@ def _create_swift_module(module_name, o_files, swiftdoc, swiftmodule, swiftsourc
         swiftmodule = swiftmodule,
         swiftsourceinfo = swiftsourceinfo,
         all_outputs = all_outputs,
+        executable = executable,
     )
 
 def _create_clang_module(module_name, o_files, hdrs, modulemap, all_outputs):

--- a/spm/internal/root.BUILD.bazel.tpl
+++ b/spm/internal/root.BUILD.bazel.tpl
@@ -3,8 +3,8 @@
 load(
     "@cgrindel_rules_spm//spm:spm.bzl", 
     "spm_package", 
-    "spm_swift_module",
-    "spm_clang_module",
+    "spm_swift_library",
+    "spm_clang_library",
 )
 
 package(default_visibility = ["//visibility:public"])

--- a/spm/internal/spm_filegroup.bzl
+++ b/spm/internal/spm_filegroup.bzl
@@ -13,47 +13,6 @@ def _derive_pkg_name(ctx):
     """
     return paths.basename(paths.dirname(ctx.build_file_path))
 
-# def _get_pkg_info(pkg_infos, pkg_name):
-#     """Returns the `SPMPackageInfo` with the specified name from the list
-#     of `SPMPackageInfo` values.
-
-#     Args:
-#         pkg_infos: A `list` of `SPMPackageInfo` values.
-#         pkg_name: A `string` representing the name of the desired
-#                   `SPMPackageInfo`.
-
-#     Returns:
-#         An `SPMPackageInfo` value.
-#     """
-#     for pi in pkg_infos:
-#         if pi.name == pkg_name:
-#             return pi
-#     fail("Could not find package with name", pkg_name)
-
-# def _get_module_info(pkg_info, module_name):
-#     """Returns the module information with the specified module name.
-
-#     Args:
-#         pkg_info: An `SPMPackageInfo` value.
-#         module_name: The module name `string`.
-
-#     Returns:
-#         If the module is a Swift module, a `struct` value as created by
-#         `providers.swift_module()` is returend. If the module is a clang
-#         module a `struct` value as created by `providers.clang_module()` is
-#         returned.
-#     """
-#     for module in pkg_info.swift_modules:
-#         if module.module_name == module_name:
-#             return module
-#     for module in pkg_info.clang_modules:
-#         if module.module_name == module_name:
-#             return module
-#     for module in pkg_info.system_library_modules:
-#         if module.module_name == module_name:
-#             return module
-#     fail("Could not find module with name", module_name, "in package", pkg_info.name)
-
 def _spm_filegroup_impl(ctx):
     pkgs_info = ctx.attr.packages[SPMPackagesInfo]
 
@@ -62,9 +21,6 @@ def _spm_filegroup_impl(ctx):
         pkg_name = _derive_pkg_name(ctx)
 
     module_name = ctx.attr.module_name
-
-    # pkg_info = _get_pkg_info(pkgs_info.packages, pkg_name)
-    # module_info = _get_module_info(pkg_info, module_name)
     pkg_info = spm_package_info_utils.get(pkgs_info.packages, pkg_name)
     module_info = spm_package_info_utils.get_module_info(pkg_info, module_name)
 

--- a/spm/internal/spm_filegroup.bzl
+++ b/spm/internal/spm_filegroup.bzl
@@ -1,4 +1,5 @@
 load(":providers.bzl", "SPMPackagesInfo")
+load(":spm_package_info_utils.bzl", "spm_package_info_utils")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 
 def _derive_pkg_name(ctx):
@@ -12,46 +13,46 @@ def _derive_pkg_name(ctx):
     """
     return paths.basename(paths.dirname(ctx.build_file_path))
 
-def _get_pkg_info(pkg_infos, pkg_name):
-    """Returns the `SPMPackageInfo` with the specified name from the list
-    of `SPMPackageInfo` values.
+# def _get_pkg_info(pkg_infos, pkg_name):
+#     """Returns the `SPMPackageInfo` with the specified name from the list
+#     of `SPMPackageInfo` values.
 
-    Args:
-        pkg_infos: A `list` of `SPMPackageInfo` values.
-        pkg_name: A `string` representing the name of the desired
-                  `SPMPackageInfo`.
+#     Args:
+#         pkg_infos: A `list` of `SPMPackageInfo` values.
+#         pkg_name: A `string` representing the name of the desired
+#                   `SPMPackageInfo`.
 
-    Returns:
-        An `SPMPackageInfo` value.
-    """
-    for pi in pkg_infos:
-        if pi.name == pkg_name:
-            return pi
-    fail("Could not find package with name", pkg_name)
+#     Returns:
+#         An `SPMPackageInfo` value.
+#     """
+#     for pi in pkg_infos:
+#         if pi.name == pkg_name:
+#             return pi
+#     fail("Could not find package with name", pkg_name)
 
-def _get_module_info(pkg_info, module_name):
-    """Returns the module information with the specified module name.
+# def _get_module_info(pkg_info, module_name):
+#     """Returns the module information with the specified module name.
 
-    Args:
-        pkg_info: An `SPMPackageInfo` value.
-        module_name: The module name `string`.
+#     Args:
+#         pkg_info: An `SPMPackageInfo` value.
+#         module_name: The module name `string`.
 
-    Returns:
-        If the module is a Swift module, a `struct` value as created by
-        `providers.swift_module()` is returend. If the module is a clang
-        module a `struct` value as created by `providers.clang_module()` is
-        returned.
-    """
-    for module in pkg_info.swift_modules:
-        if module.module_name == module_name:
-            return module
-    for module in pkg_info.clang_modules:
-        if module.module_name == module_name:
-            return module
-    for module in pkg_info.system_library_modules:
-        if module.module_name == module_name:
-            return module
-    fail("Could not find module with name", module_name, "in package", pkg_info.name)
+#     Returns:
+#         If the module is a Swift module, a `struct` value as created by
+#         `providers.swift_module()` is returend. If the module is a clang
+#         module a `struct` value as created by `providers.clang_module()` is
+#         returned.
+#     """
+#     for module in pkg_info.swift_modules:
+#         if module.module_name == module_name:
+#             return module
+#     for module in pkg_info.clang_modules:
+#         if module.module_name == module_name:
+#             return module
+#     for module in pkg_info.system_library_modules:
+#         if module.module_name == module_name:
+#             return module
+#     fail("Could not find module with name", module_name, "in package", pkg_info.name)
 
 def _spm_filegroup_impl(ctx):
     pkgs_info = ctx.attr.packages[SPMPackagesInfo]
@@ -62,8 +63,10 @@ def _spm_filegroup_impl(ctx):
 
     module_name = ctx.attr.module_name
 
-    pkg_info = _get_pkg_info(pkgs_info.packages, pkg_name)
-    module_info = _get_module_info(pkg_info, module_name)
+    # pkg_info = _get_pkg_info(pkgs_info.packages, pkg_name)
+    # module_info = _get_module_info(pkg_info, module_name)
+    pkg_info = spm_package_info_utils.get(pkgs_info.packages, pkg_name)
+    module_info = spm_package_info_utils.get_module_info(pkg_info, module_name)
 
     output = []
     file_type = ctx.attr.file_type

--- a/spm/internal/spm_package.bzl
+++ b/spm/internal/spm_package.bzl
@@ -56,10 +56,7 @@ def _declare_swift_executable_target_files(ctx, target, build_config_path):
 
     return providers.swift_module(
         module_name = module_name,
-        o_files = [],
-        swiftdoc = None,
-        swiftmodule = None,
-        swiftsourceinfo = None,
+        executable = executable,
         all_outputs = [executable],
     )
 

--- a/spm/internal/spm_package.bzl
+++ b/spm/internal/spm_package.bzl
@@ -175,22 +175,30 @@ def _gather_package_build_info(
         ref_type, pname, target_name = refs.split(target_ref)
         target = pds.get_target(pkg_desc, target_name)
 
-        if pds.is_swift_module(target):
-            swift_module_info = _declare_swift_target_files(ctx, target, build_config_path)
-            swift_modules.append(swift_module_info)
-            build_outs.extend(swift_module_info.all_outputs)
+        if pds.is_swift_target(target):
+            if pds.is_library_target(target):
+                swift_module_info = _declare_swift_target_files(ctx, target, build_config_path)
+                swift_modules.append(swift_module_info)
+                build_outs.extend(swift_module_info.all_outputs)
+            elif pds.is_executable_target(target):
+                fail("IMPLEMENT ME: %s" % (target))
+            else:
+                fail("Unrecognized Swift target type. %s" % (target))
 
-        elif pds.is_clang_module(target):
-            clang_module_info = _declare_clang_target_files(
-                ctx,
-                target,
-                build_config_path,
-                clang_custom_infos_dict[target["name"]],
-            )
-            clang_modules.append(clang_module_info)
-            build_outs.extend(clang_module_info.all_outputs)
+        elif pds.is_clang_target(target):
+            if pds.is_library_target(target):
+                clang_module_info = _declare_clang_target_files(
+                    ctx,
+                    target,
+                    build_config_path,
+                    clang_custom_infos_dict[target["name"]],
+                )
+                clang_modules.append(clang_module_info)
+                build_outs.extend(clang_module_info.all_outputs)
+            else:
+                fail("Unrecognized clang target type. %s" % (target))
 
-        elif pds.is_system_library_module(target):
+        elif pds.is_system_library_target(target):
             system_library_module_info = _declare_system_library_target_files(
                 ctx,
                 pname,

--- a/spm/internal/spm_package_info_utils.bzl
+++ b/spm/internal/spm_package_info_utils.bzl
@@ -1,0 +1,45 @@
+def _get(pkg_infos, pkg_name):
+    """Returns the `SPMPackageInfo` with the specified name from the list
+    of `SPMPackageInfo` values.
+
+    Args:
+        pkg_infos: A `list` of `SPMPackageInfo` values.
+        pkg_name: A `string` representing the name of the desired
+                  `SPMPackageInfo`.
+
+    Returns:
+        An `SPMPackageInfo` value.
+    """
+    for pi in pkg_infos:
+        if pi.name == pkg_name:
+            return pi
+    fail("Could not find package with name", pkg_name)
+
+def _get_module_info(pkg_info, module_name):
+    """Returns the module information with the specified module name.
+
+    Args:
+        pkg_info: An `SPMPackageInfo` value.
+        module_name: The module name `string`.
+
+    Returns:
+        If the module is a Swift module, a `struct` value as created by
+        `providers.swift_module()` is returend. If the module is a clang
+        module a `struct` value as created by `providers.clang_module()` is
+        returned.
+    """
+    for module in pkg_info.swift_modules:
+        if module.module_name == module_name:
+            return module
+    for module in pkg_info.clang_modules:
+        if module.module_name == module_name:
+            return module
+    for module in pkg_info.system_library_modules:
+        if module.module_name == module_name:
+            return module
+    fail("Could not find module with name", module_name, "in package", pkg_info.name)
+
+spm_package_info_utils = struct(
+    get = _get,
+    get_module_info = _get_module_info,
+)

--- a/spm/internal/spm_repositories.bzl
+++ b/spm/internal/spm_repositories.bzl
@@ -517,6 +517,21 @@ def _configure_spm_repository(repository_ctx, pkgs):
     # Create Bazel targets for every declared product and any of its transitive
     # dependencies
     declared_product_refs = packages.get_product_refs(pkgs)
+
+    # DEBUG BEGIN
+    pkg_descs_dict_json = json.encode_indent(pkg_descs_dict, indent = "  ")
+    repository_ctx.file("pkg_descs.json", content = pkg_descs_dict_json, executable = False)
+
+    # print("*** CHUCK pkg_descs_dict_json:\n", pkg_descs_dict_json)
+    # print("*** CHUCK pkg_descs_dict: ")
+    # for idx, item in enumerate(pkg_descs_dict):
+    #     print("*** CHUCK", idx, ":", item)
+
+    # print("*** CHUCK pkg_descs_dict: ")
+    # for key in pkg_descs_dict:
+    #     print("*** CHUCK", key, ":", pkg_descs_dict[key])
+
+    # DEBUG END
     dep_target_refs_dict = pds.transitive_dependencies(pkg_descs_dict, declared_product_refs)
     for pkg_name in pkg_descs_dict:
         _generate_bazel_pkg(

--- a/spm/internal/spm_repositories.bzl
+++ b/spm/internal/spm_repositories.bzl
@@ -215,21 +215,21 @@ def _generate_bazel_pkg(repository_ctx, pkg_desc, dep_target_refs_dict, clang_hd
         target_deps = dep_target_refs_dict[target_ref]
         rtype, pname, target_name = refs.split(target_ref)
         target = pds.get_target(pkg_desc, target_name)
-        if pds.is_clang_module(target):
+        if pds.is_clang_target(target):
             module_decls.append(_create_spm_clang_module_decl(
                 repository_ctx,
                 pkg_name,
                 target,
                 target_deps,
             ))
-        elif pds.is_swift_module(target):
+        elif pds.is_swift_target(target):
             module_decls.append(_create_spm_swift_module_decl(
                 repository_ctx,
                 pkg_name,
                 target,
                 target_deps,
             ))
-        elif pds.is_system_library_module(target):
+        elif pds.is_system_library_target(target):
             module_decls.append(_create_spm_system_library_module_decl(
                 repository_ctx,
                 pkg_name,
@@ -529,7 +529,7 @@ def _configure_spm_repository(repository_ctx, pkgs):
         pkg_descs_dict[dep_name] = dep_pkg_desc
 
         # Look for custom header declarations in the clang targets
-        clang_targets = [t for t in pds.library_targets(dep_pkg_desc) if pds.is_clang_module(t)]
+        clang_targets = [t for t in pds.library_targets(dep_pkg_desc) if pds.is_clang_target(t)]
         for clang_target in clang_targets:
             clang_hdr_paths = _get_clang_hdrs_for_target(
                 repository_ctx,

--- a/spm/internal/spm_repositories.bzl
+++ b/spm/internal/spm_repositories.bzl
@@ -275,7 +275,7 @@ def _generate_bazel_pkg(repository_ctx, pkg_desc, dep_target_refs_dict, clang_hd
                     pkg_root_path,
                 ))
             else:
-                fail("Unrecognized clang target type. %s" % (target))
+                fail("Unrecognized system target type. %s" % (target))
         else:
             fail("Unrecognized target type. %s" % (target))
 

--- a/spm/internal/spm_repositories.bzl
+++ b/spm/internal/spm_repositories.bzl
@@ -266,7 +266,7 @@ def _generate_bazel_pkg(repository_ctx, pkg_desc, dep_target_refs_dict, clang_hd
                 fail("Unrecognized Swift target type. %s" % (target))
 
         elif pds.is_system_library_target(target):
-            if pds.is_library_target(target):
+            if pds.is_system_target(target):
                 module_decls.append(_create_spm_system_library_decl(
                     repository_ctx,
                     pkg_name,

--- a/spm/internal/spm_repositories.bzl
+++ b/spm/internal/spm_repositories.bzl
@@ -518,20 +518,6 @@ def _configure_spm_repository(repository_ctx, pkgs):
     # dependencies
     declared_product_refs = packages.get_product_refs(pkgs)
 
-    # DEBUG BEGIN
-    pkg_descs_dict_json = json.encode_indent(pkg_descs_dict, indent = "  ")
-    repository_ctx.file("pkg_descs.json", content = pkg_descs_dict_json, executable = False)
-
-    # print("*** CHUCK pkg_descs_dict_json:\n", pkg_descs_dict_json)
-    # print("*** CHUCK pkg_descs_dict: ")
-    # for idx, item in enumerate(pkg_descs_dict):
-    #     print("*** CHUCK", idx, ":", item)
-
-    # print("*** CHUCK pkg_descs_dict: ")
-    # for key in pkg_descs_dict:
-    #     print("*** CHUCK", key, ":", pkg_descs_dict[key])
-
-    # DEBUG END
     dep_target_refs_dict = pds.transitive_dependencies(pkg_descs_dict, declared_product_refs)
     for pkg_name in pkg_descs_dict:
         _generate_bazel_pkg(

--- a/spm/internal/spm_repositories.bzl
+++ b/spm/internal/spm_repositories.bzl
@@ -49,6 +49,38 @@ def _list_directories_under(repository_ctx, path, max_depth = None):
     paths = exec_result.stdout.splitlines()
     return [p for p in paths if p != path]
 
+def _find_and_delete_files(repository_ctx, path, name):
+    # find_args = ["find", path, "-type", "f", "-name", "'%s'" % (name)]
+    # rm_args = ["rm", "-f", "-v"]
+    # all_args = find_args + ["|"] + rm_args
+    # find_args = ["find", path, "-type", "f", "-name", "'%s'" % (name)]
+    # find_args = ["find", path]
+
+    # WORK
+    # find_args = ["find", path, "-name", "%s" % (name)]
+    # find_args = ["find", path, "-name", name]
+    find_args = ["find", path, "-type", "f", "-name", name]
+
+    rm_args = ["-delete"]
+
+    # rm_args = []
+    all_args = find_args + rm_args
+    exec_result = repository_ctx.execute(all_args, quiet = True)
+
+    # DEBUG BEGIN
+    print("*** CHUCK _find_and_delete_files path: ", path)
+    print("*** CHUCK _find_and_delete_files name: ", name)
+    print("*** CHUCK _find_and_delete_files all_args: ", all_args)
+    print("*** CHUCK _find_and_delete_files exec_result.stdout: ", exec_result.stdout)
+
+    # DEBUG END
+    if exec_result.return_code != 0:
+        fail("Failed to remove files named {name} under {path}. stderr:\n{stderr}".format(
+            name = name,
+            path = path,
+            stderr = exec_result.stderr,
+        ))
+
 # MARK: - Module Declaration Functions
 
 _spm_swift_module_tpl = """
@@ -483,6 +515,14 @@ def _configure_spm_repository(repository_ctx, pkgs):
             repository_ctx.attr.name,
             resolve_result.stderr,
         ))
+
+    # Remove any BUILD or BUILD.bazel files in the fetched repos. The presence
+    # of these files will prevent glob() from finding the source files because
+    # Bazel will consider the directories with the BUILD/BUILD.bazel files to
+    # legitimate packages. See glob() documentation for more details:
+    # https://docs.bazel.build/versions/main/be/functions.html#glob
+    _find_and_delete_files(repository_ctx, spm_common.checkouts_path, name = "BUILD")
+    _find_and_delete_files(repository_ctx, spm_common.checkouts_path, name = "BUILD.bazel")
 
     pkg_descs_dict = dict()
     clang_hdrs_dict = dict()

--- a/spm/internal/spm_repositories.bzl
+++ b/spm/internal/spm_repositories.bzl
@@ -562,6 +562,19 @@ def _configure_spm_repository(repository_ctx, pkgs):
 def _spm_repositories_impl(repository_ctx):
     pkgs = [packages.from_json(j) for j in repository_ctx.attr.dependencies]
 
+    # DEBUG BEGIN
+    print("*** CHUCK repository_ctx.attr.name: ", repository_ctx.attr.name)
+    print("*** CHUCK pkgs: ")
+    for idx, item in enumerate(pkgs):
+        print("*** CHUCK", idx, ":", item)
+
+    exec_result = repository_ctx.execute(
+        ["pwd"],
+        quiet = True,
+    )
+    print("*** CHUCK exec_result.stdout: ", exec_result.stdout)
+    # DEBUG END
+
     # Generate Package.swift
     _generate_package_swift_file(repository_ctx, pkgs)
 

--- a/spm/internal/spm_repositories.bzl
+++ b/spm/internal/spm_repositories.bzl
@@ -562,19 +562,6 @@ def _configure_spm_repository(repository_ctx, pkgs):
 def _spm_repositories_impl(repository_ctx):
     pkgs = [packages.from_json(j) for j in repository_ctx.attr.dependencies]
 
-    # DEBUG BEGIN
-    print("*** CHUCK repository_ctx.attr.name: ", repository_ctx.attr.name)
-    print("*** CHUCK pkgs: ")
-    for idx, item in enumerate(pkgs):
-        print("*** CHUCK", idx, ":", item)
-
-    exec_result = repository_ctx.execute(
-        ["pwd"],
-        quiet = True,
-    )
-    print("*** CHUCK exec_result.stdout: ", exec_result.stdout)
-    # DEBUG END
-
     # Generate Package.swift
     _generate_package_swift_file(repository_ctx, pkgs)
 

--- a/spm/internal/spm_repositories.bzl
+++ b/spm/internal/spm_repositories.bzl
@@ -50,30 +50,18 @@ def _list_directories_under(repository_ctx, path, max_depth = None):
     return [p for p in paths if p != path]
 
 def _find_and_delete_files(repository_ctx, path, name):
-    # find_args = ["find", path, "-type", "f", "-name", "'%s'" % (name)]
-    # rm_args = ["rm", "-f", "-v"]
-    # all_args = find_args + ["|"] + rm_args
-    # find_args = ["find", path, "-type", "f", "-name", "'%s'" % (name)]
-    # find_args = ["find", path]
+    """Finds files with the specified name under the specified path and 
+    deletes them.
 
-    # WORK
-    # find_args = ["find", path, "-name", "%s" % (name)]
-    # find_args = ["find", path, "-name", name]
+    Args:
+        repository_ctx: A `repository_ctx` instance.
+        path: A path `string` value.
+        name: A file basename as a `string`.
+    """
     find_args = ["find", path, "-type", "f", "-name", name]
-
     rm_args = ["-delete"]
-
-    # rm_args = []
     all_args = find_args + rm_args
     exec_result = repository_ctx.execute(all_args, quiet = True)
-
-    # DEBUG BEGIN
-    print("*** CHUCK _find_and_delete_files path: ", path)
-    print("*** CHUCK _find_and_delete_files name: ", name)
-    print("*** CHUCK _find_and_delete_files all_args: ", all_args)
-    print("*** CHUCK _find_and_delete_files exec_result.stdout: ", exec_result.stdout)
-
-    # DEBUG END
     if exec_result.return_code != 0:
         fail("Failed to remove files named {name} under {path}. stderr:\n{stderr}".format(
             name = name,
@@ -519,7 +507,7 @@ def _configure_spm_repository(repository_ctx, pkgs):
     # Remove any BUILD or BUILD.bazel files in the fetched repos. The presence
     # of these files will prevent glob() from finding the source files because
     # Bazel will consider the directories with the BUILD/BUILD.bazel files to
-    # legitimate packages. See glob() documentation for more details:
+    # be legitimate packages. See glob() documentation for more details:
     # https://docs.bazel.build/versions/main/be/functions.html#glob
     _find_and_delete_files(repository_ctx, spm_common.checkouts_path, name = "BUILD")
     _find_and_delete_files(repository_ctx, spm_common.checkouts_path, name = "BUILD.bazel")

--- a/spm/internal/spm_swift_binary.bzl
+++ b/spm/internal/spm_swift_binary.bzl
@@ -1,0 +1,70 @@
+load(":providers.bzl", "SPMPackagesInfo")
+load(":spm_package_info_utils.bzl", "spm_package_info_utils")
+load("@bazel_skylib//lib:paths.bzl", "paths")
+
+def _derive_pkg_name(ctx):
+    """Determines the Swift package name from the Bazel package name.
+
+    Args:
+        ctx: A `ctx` instance.
+
+    Returns:
+        A `string` representing the Swift package name.
+    """
+    return paths.basename(paths.dirname(ctx.build_file_path))
+
+def _spm_swift_binary_impl(ctx):
+    pkgs_info = ctx.attr.packages[SPMPackagesInfo]
+
+    pkg_name = ctx.attr.package_name
+    if pkg_name == "":
+        pkg_name = _derive_pkg_name(ctx)
+
+    module_name = ctx.attr.module_name
+    if module_name == "":
+        module_name = ctx.attr.name
+
+    pkg_info = spm_package_info_utils.get(pkgs_info.packages, pkg_name)
+    module_info = spm_package_info_utils.get_module_info(pkg_info, module_name)
+
+    if module_info.executable == None:
+        fail("The specified module (%s) is not executable." % (module_name))
+
+    # Bazel will error if we try to return a file that we did not create as
+    # the executable. So, we symlink it.
+    executable = ctx.actions.declare_file(module_info.executable.basename)
+    ctx.actions.symlink(
+        output = executable,
+        target_file = module_info.executable,
+    )
+
+    return [
+        DefaultInfo(executable = executable),
+    ]
+
+spm_swift_binary = rule(
+    implementation = _spm_swift_binary_impl,
+    executable = True,
+    attrs = {
+        "packages": attr.label(
+            mandatory = True,
+            providers = [[SPMPackagesInfo]],
+            doc = """\
+            A target that outputs an SPMPackagesInfo (e.g. spm_pacakge).\
+            """,
+        ),
+        "package_name": attr.string(
+            doc = """\
+            The name of the package that exports this module. If no value 
+            provided, it will be derived from the Bazel package name.\
+            """,
+        ),
+        "module_name": attr.string(
+            doc = """\
+            The name of the executable module in the SPM package. If no value
+            is provided, it will be derived from the name attribute.\
+            """,
+        ),
+    },
+    doc = "Builds the specified Swift package.",
+)

--- a/spm/internal/spm_swift_library.bzl
+++ b/spm/internal/spm_swift_library.bzl
@@ -1,8 +1,8 @@
-load( "@build_bazel_rules_swift//swift:swift.bzl", "swift_import")
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_import")
 load(":spm_filegroup.bzl", "spm_filegroup")
 load(":spm_archive.bzl", "spm_archive")
 
-def spm_swift_module(name, packages, deps = None, visibility = None):
+def spm_swift_library(name, packages, deps = None, visibility = None):
     """Exposes a Swift module as defined in a dependent Swift package.
 
     Args:
@@ -38,7 +38,7 @@ def spm_swift_module(name, packages, deps = None, visibility = None):
         module_name = module_name,
         file_type = "o_files",
     )
-    
+
     a_file_name = "%s_a_file" % (name)
     spm_archive(
         name = a_file_name,

--- a/spm/internal/spm_system_library.bzl
+++ b/spm/internal/spm_system_library.bzl
@@ -1,18 +1,29 @@
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_c_module",
+)
 load("//spm/internal:spm_filegroup.bzl", "spm_filegroup")
-load(":package_descriptions.bzl", "module_types", pds = "package_descriptions")
 
-def spm_clang_module(name, packages, deps = None, visibility = None):
-    """Exposes a clang module as defined in a dependent Swift package.
+def spm_system_library(name, packages, deps = None, visibility = None):
+    """Exposes a system library module as defined in a dependent Swift package.
 
     Args:
         name: The Bazel target name.
         packages: A target that outputs an SPMPackagesInfo provider (e.g.
                   `spm_package`).
-        deps: Dependencies appropriate for the `objc_library` which defines
+        deps: Dependencies appropriate for the `swift_c_module` which defines
               the target.
         visibility: Target visibility.
     """
     module_name = name
+
+    modulemap_files_name = "%s_modulemap" % (name)
+    spm_filegroup(
+        name = modulemap_files_name,
+        packages = packages,
+        module_name = module_name,
+        file_type = "modulemap",
+    )
 
     hdr_files_name = "%s_hdrs" % (name)
     spm_filegroup(
@@ -27,20 +38,28 @@ def spm_clang_module(name, packages, deps = None, visibility = None):
         name = src_files_name,
         packages = packages,
         module_name = module_name,
-        file_type = "o_files",
+        file_type = "c_files",
     )
 
+    cc_lib_name = "%s_cc_lib" % (name)
     native.cc_library(
-        name = name,
+        name = cc_lib_name,
         hdrs = [
             ":%s" % (hdr_files_name),
         ],
         srcs = [
             ":%s" % (src_files_name),
         ],
-        tags = [
-            "swift_module=%s" % (module_name),
-        ],
+        tags = ["swift_module=%s" % (name)],
         deps = deps,
+    )
+
+    swift_c_module(
+        name = name,
+        deps = [
+            ":%s" % (cc_lib_name),
+        ],
+        module_map = ":%s" % (modulemap_files_name),
+        module_name = name,
         visibility = visibility,
     )

--- a/spm/spm.bzl
+++ b/spm/spm.bzl
@@ -8,16 +8,16 @@ load(
     _spm_repositories = "spm_repositories",
 )
 load(
-    "//spm/internal:spm_swift_module.bzl",
-    _spm_swift_module = "spm_swift_module",
+    "//spm/internal:spm_swift_library.bzl",
+    _spm_swift_library = "spm_swift_library",
 )
 load(
-    "//spm/internal:spm_clang_module.bzl",
-    _spm_clang_module = "spm_clang_module",
+    "//spm/internal:spm_clang_library.bzl",
+    _spm_clang_library = "spm_clang_library",
 )
 load(
-    "//spm/internal:spm_system_library_module.bzl",
-    _spm_system_library_module = "spm_system_library_module",
+    "//spm/internal:spm_system_library.bzl",
+    _spm_system_library = "spm_system_library",
 )
 load(
     "//spm/internal:spm_archive.bzl",
@@ -30,7 +30,7 @@ spm_pkg = _spm_pkg
 
 # Regular Rules and Macros
 spm_package = _spm_package
-spm_swift_module = _spm_swift_module
-spm_clang_module = _spm_clang_module
-spm_system_library_module = _spm_system_library_module
+spm_swift_library = _spm_swift_library
+spm_clang_library = _spm_clang_library
+spm_system_library = _spm_system_library
 spm_archive = _spm_archive

--- a/spm/spm.bzl
+++ b/spm/spm.bzl
@@ -12,6 +12,10 @@ load(
     _spm_swift_library = "spm_swift_library",
 )
 load(
+    "//spm/internal:spm_swift_binary.bzl",
+    _spm_swift_binary = "spm_swift_binary",
+)
+load(
     "//spm/internal:spm_clang_library.bzl",
     _spm_clang_library = "spm_clang_library",
 )
@@ -30,6 +34,7 @@ spm_pkg = _spm_pkg
 
 # Regular Rules and Macros
 spm_package = _spm_package
+spm_swift_binary = _spm_swift_binary
 spm_swift_library = _spm_swift_library
 spm_clang_library = _spm_clang_library
 spm_system_library = _spm_system_library

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -5,6 +5,7 @@ load(":spm_common_tests.bzl", "spm_common_test_suite")
 load(":references_tests.bzl", "references_test_suite")
 load(":platforms_tests.bzl", "platforms_test_suite")
 load(":swift_toolchains_tests.bzl", "swift_toolchains_test_suite")
+load(":spm_package_info_utils_tests.bzl", "spm_package_info_utils_test_suite")
 
 package_descriptions_test_suite()
 
@@ -19,3 +20,5 @@ references_test_suite()
 platforms_test_suite()
 
 swift_toolchains_test_suite()
+
+spm_package_info_utils_test_suite()

--- a/test/package_descriptions_tests.bzl
+++ b/test/package_descriptions_tests.bzl
@@ -67,6 +67,15 @@ def _is_library_target_test(ctx):
 
 is_library_target_test = unittest.make(_is_library_target_test)
 
+def _is_executable_target_test(ctx):
+    env = unittest.begin(ctx)
+
+    unittest.fail(env, "IMPLEMENT ME!")
+
+    return unittest.end(env)
+
+is_executable_target_test = unittest.make(_is_executable_target_test)
+
 def _library_targets_test(ctx):
     env = unittest.begin(ctx)
 
@@ -110,50 +119,50 @@ def _dependency_repository_name_test(ctx):
 
 dependency_repository_name_test = unittest.make(_dependency_repository_name_test)
 
-def _is_system_library_module_test(ctx):
+def _is_system_library_target_test(ctx):
     env = unittest.begin(ctx)
 
     target = {"module_type": module_types.system_library}
-    asserts.true(env, pds.is_system_library_module(target))
+    asserts.true(env, pds.is_system_library_target(target))
 
     target = {"module_type": module_types.clang}
-    asserts.false(env, pds.is_system_library_module(target))
+    asserts.false(env, pds.is_system_library_target(target))
 
     target = {"module_type": module_types.swift}
-    asserts.false(env, pds.is_system_library_module(target))
+    asserts.false(env, pds.is_system_library_target(target))
 
     return unittest.end(env)
 
-is_system_library_module_test = unittest.make(_is_system_library_module_test)
+is_system_library_target_test = unittest.make(_is_system_library_target_test)
 
-def _is_clang_module_test(ctx):
+def _is_clang_target_test(ctx):
     env = unittest.begin(ctx)
 
     target = {"module_type": module_types.clang}
-    asserts.true(env, pds.is_clang_module(target))
+    asserts.true(env, pds.is_clang_target(target))
 
     target = {"module_type": module_types.system_library}
-    asserts.false(env, pds.is_clang_module(target))
+    asserts.false(env, pds.is_clang_target(target))
 
     target = {"module_type": module_types.swift}
-    asserts.false(env, pds.is_clang_module(target))
+    asserts.false(env, pds.is_clang_target(target))
 
     return unittest.end(env)
 
-is_clang_module_test = unittest.make(_is_clang_module_test)
+is_clang_target_test = unittest.make(_is_clang_target_test)
 
-def _is_swift_module_test(ctx):
+def _is_swift_target_test(ctx):
     env = unittest.begin(ctx)
 
     target = {"module_type": module_types.swift}
-    asserts.true(env, pds.is_swift_module(target))
+    asserts.true(env, pds.is_swift_target(target))
 
     target = {"module_type": module_types.clang}
-    asserts.false(env, pds.is_swift_module(target))
+    asserts.false(env, pds.is_swift_target(target))
 
     return unittest.end(env)
 
-is_swift_module_test = unittest.make(_is_swift_module_test)
+is_swift_target_test = unittest.make(_is_swift_target_test)
 
 def _get_target_test(ctx):
     env = unittest.begin(ctx)
@@ -270,11 +279,12 @@ def package_descriptions_test_suite():
         is_library_product_test,
         library_products_test,
         is_library_target_test,
+        is_executable_target_test,
         library_targets_test,
         dependency_name_test,
-        is_system_library_module_test,
-        is_clang_module_test,
-        is_swift_module_test,
+        is_system_library_target_test,
+        is_clang_target_test,
+        is_swift_target_test,
         get_target_test,
         transitive_dependencies_test,
     )

--- a/test/package_descriptions_tests.bzl
+++ b/test/package_descriptions_tests.bzl
@@ -70,7 +70,10 @@ is_library_target_test = unittest.make(_is_library_target_test)
 def _is_executable_target_test(ctx):
     env = unittest.begin(ctx)
 
-    unittest.fail(env, "IMPLEMENT ME!")
+    target = {"type": "library"}
+    asserts.false(env, pds.is_executable_target(target))
+    target["type"] = "executable"
+    asserts.true(env, pds.is_executable_target(target))
 
     return unittest.end(env)
 

--- a/test/package_descriptions_tests.bzl
+++ b/test/package_descriptions_tests.bzl
@@ -79,6 +79,18 @@ def _is_executable_target_test(ctx):
 
 is_executable_target_test = unittest.make(_is_executable_target_test)
 
+def _is_system_target_test(ctx):
+    env = unittest.begin(ctx)
+
+    target = {"type": "library"}
+    asserts.false(env, pds.is_system_target(target))
+    target["type"] = "system-target"
+    asserts.true(env, pds.is_system_target(target))
+
+    return unittest.end(env)
+
+is_system_target_test = unittest.make(_is_system_target_test)
+
 def _library_targets_test(ctx):
     env = unittest.begin(ctx)
 
@@ -283,6 +295,7 @@ def package_descriptions_test_suite():
         library_products_test,
         is_library_target_test,
         is_executable_target_test,
+        is_system_target_test,
         library_targets_test,
         dependency_name_test,
         is_system_library_target_test,

--- a/test/providers_tests.bzl
+++ b/test/providers_tests.bzl
@@ -6,11 +6,11 @@ def _swift_module_test(ctx):
 
     result = providers.swift_module(
         "MyModule",
-        ["first.o", "second.o"],
-        "MyModule.swiftdoc",
-        "MyModule.swiftmodule",
-        "MyModule.swiftsourceinfo",
-        ["all"],
+        o_files = ["first.o", "second.o"],
+        swiftdoc = "MyModule.swiftdoc",
+        swiftmodule = "MyModule.swiftmodule",
+        swiftsourceinfo = "MyModule.swiftsourceinfo",
+        all_outputs = ["all"],
     )
     expected = struct(
         module_name = "MyModule",
@@ -18,6 +18,23 @@ def _swift_module_test(ctx):
         swiftdoc = "MyModule.swiftdoc",
         swiftmodule = "MyModule.swiftmodule",
         swiftsourceinfo = "MyModule.swiftsourceinfo",
+        executable = None,
+        all_outputs = ["all"],
+    )
+    asserts.equals(env, expected, result)
+
+    result = providers.swift_module(
+        "MyExecutable",
+        executable = "my_executable",
+        all_outputs = ["all"],
+    )
+    expected = struct(
+        module_name = "MyExecutable",
+        o_files = [],
+        swiftdoc = None,
+        swiftmodule = None,
+        swiftsourceinfo = None,
+        executable = "my_executable",
         all_outputs = ["all"],
     )
     asserts.equals(env, expected, result)

--- a/test/spm_package_info_utils_tests.bzl
+++ b/test/spm_package_info_utils_tests.bzl
@@ -1,0 +1,26 @@
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+
+def _get_test(ctx):
+    env = unittest.begin(ctx)
+
+    unittest.fail(env, "IMPLEMENT ME!")
+
+    return unittest.end(env)
+
+get_test = unittest.make(_get_test)
+
+def _get_module_info_test(ctx):
+    env = unittest.begin(ctx)
+
+    unittest.fail(env, "IMPLEMENT ME!")
+
+    return unittest.end(env)
+
+get_module_info_test = unittest.make(_get_module_info_test)
+
+def spm_package_info_utils_test_suite():
+    return unittest.suite(
+        "spm_package_info_utils_tests",
+        get_test,
+        get_module_info_test,
+    )

--- a/test/spm_package_info_utils_tests.bzl
+++ b/test/spm_package_info_utils_tests.bzl
@@ -1,9 +1,28 @@
+load("//spm/internal:spm_package_info_utils.bzl", "spm_package_info_utils")
+load("//spm/internal:providers.bzl", "SPMPackageInfo", "providers")
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 
 def _get_test(ctx):
     env = unittest.begin(ctx)
 
-    unittest.fail(env, "IMPLEMENT ME!")
+    pkg_infos = [
+        SPMPackageInfo(
+            name = "hello",
+            swift_modules = [],
+            clang_modules = [],
+            system_library_modules = [],
+        ),
+        SPMPackageInfo(
+            name = "goodbye",
+            swift_modules = [],
+            clang_modules = [],
+            system_library_modules = [],
+        ),
+    ]
+    result = spm_package_info_utils.get(pkg_infos, "goodbye")
+    asserts.equals(env, "goodbye", result.name)
+    result = spm_package_info_utils.get(pkg_infos, "hello")
+    asserts.equals(env, "hello", result.name)
 
     return unittest.end(env)
 
@@ -12,7 +31,30 @@ get_test = unittest.make(_get_test)
 def _get_module_info_test(ctx):
     env = unittest.begin(ctx)
 
-    unittest.fail(env, "IMPLEMENT ME!")
+    pkg_info = SPMPackageInfo(
+        name = "hello",
+        swift_modules = [
+            providers.swift_module("MySwift"),
+            providers.swift_module("NotMySwift"),
+        ],
+        clang_modules = [
+            providers.clang_module("MyClang"),
+            providers.clang_module("NotMyClang"),
+        ],
+        system_library_modules = [
+            providers.system_library_module("MySystem"),
+            providers.system_library_module("NotMySystem"),
+        ],
+    )
+
+    result = spm_package_info_utils.get_module_info(pkg_info, "MySwift")
+    asserts.equals(env, "MySwift", result.module_name)
+
+    result = spm_package_info_utils.get_module_info(pkg_info, "MyClang")
+    asserts.equals(env, "MyClang", result.module_name)
+
+    result = spm_package_info_utils.get_module_info(pkg_info, "MySystem")
+    asserts.equals(env, "MySystem", result.module_name)
 
     return unittest.end(env)
 


### PR DESCRIPTION
Closes #56.

- Added support for executable SPM targets (`spm_swift_binary`).
- Updated the `byName` resolution to look in a number of places to resolve the name. Apparently, before Swift 5.2, the search was very wide. In Swift 5.2, `byName` references need to match the package name and the module name. This implementation favors the 5.2 logic. It will look elsewhere if the restrictive search fails.
- Added `simple_with_binary` example which demonstrates the declaration and use of a third-party binary.
- Updated the SPM fetch logic to remove any `BUILD` or `BUILD.bazel` files in fetched repositories. Bazel will treat directories with build files as legitimate packages. As a result, Bazel's `glob()` will ignore files under those directories.