### PR TITLE
Updated workspace path resolution to work with a default label value.

### DIFF
--- a/examples/local_package/README.md
+++ b/examples/local_package/README.md
@@ -4,8 +4,9 @@ This example demonstrates the use of a local Swift package.
 
 ## Local Package with Absolute Path
 
-To reference a local Swift package with an absolute path, one needs to specify the `path` and the
-`products`.
+To reference a local Swift package, one needs to specify the `path` and the `products` in the
+`spm_pkg` declaration. The `path` value can be an absolute path or a relative path. The relative
+path is resolved realtive to the root of the Bazel workspace.
 
 ```python
 spm_repositories(
@@ -17,29 +18,6 @@ spm_repositories(
             products = ["FooKit"],
         ),
     ],
-)
-```
-
-## Local Package with Relative Path
-
-To reference a local Swift package with a relative path, the package reference specifies the `path`
-and the `products`. In addition, the `workspace_file` attribute must be provided on the
-`spm_repositories` declaration.  Specifically, it must be `workspace_file = "//:WORKSPACE"`. This
-allows the rule to find the `WORKSPACE` file which is used to evaluate the relative path in the
-`spm_pkg` declaration.
-
-```python
-spm_repositories(
-    name = "swift_pkgs",
-    dependencies = [
-        # Reference to a local package.
-        spm_pkg(
-            path = "third_party/foo-kit",
-            products = ["FooKit"],
-        ),
-    ],
-    # If using relative paths, one must provide the `workspace_file`.
-    workspace_file = "//:WORKSPACE",
 )
 ```
 

--- a/examples/local_package/WORKSPACE
+++ b/examples/local_package/WORKSPACE
@@ -55,6 +55,4 @@ spm_repositories(
             products = ["FooKit"],
         ),
     ],
-    # If using relative paths, one must provide the `workspace_file`.
-    workspace_file = "//:WORKSPACE",
 )

--- a/spm/internal/spm_repositories.bzl
+++ b/spm/internal/spm_repositories.bzl
@@ -617,12 +617,7 @@ def _configure_spm_repository(repository_ctx, pkgs):
 def _prepare_local_package(repository_ctx, pkg):
     path = pkg.path
     if not paths.is_absolute(path):
-        if repository_ctx.attr.workspace_file == "":
-            fail("""\
-                 Need to specify the `workspace_file` attribute when using \
-                 relative paths for local packages.\
-                 """)
-        repo_root = str(repository_ctx.path(repository_ctx.attr.workspace_file).dirname)
+        repo_root = str(repository_ctx.path(repository_ctx.attr._workspace_file).dirname)
         path = paths.join(repo_root, path)
 
     return packages.copy(pkg, path = path)
@@ -671,10 +666,11 @@ spm_repositories = repository_rule(
             (e.g. .macOS(.v10_15))\
             """,
         ),
-        "workspace_file": attr.label(
+        "_workspace_file": attr.label(
+            default = "@//:WORKSPACE",
             doc = """\
-            If using any local packages, this attribute needs to be set to the value \
-            `//:WORKSPACE`.\
+            The value of this label helps the rule find the root of the Bazel \
+            workspace for local path resolution.\
             """,
         ),
         "_package_swift_tpl": attr.label(


### PR DESCRIPTION
Related to #60.
Big thanks to @acecilia for pointing out the magic of the `@` symbol in `@//:WORKSPACE`.

- Converted `workspace_file` attribute to `_workspace_file` in `spm_repositories`. Added a default value that always resolves to the client's workspace.
- Updated the `README.md` to reflect the streamlined usage for relative paths.