### PR TITLE
Added minimum version check for Swift Package Manager.

### DIFF
--- a/spm/internal/spm_repositories.bzl
+++ b/spm/internal/spm_repositories.bzl
@@ -629,9 +629,9 @@ def _check_spm_version(repository_ctx):
     spm_ver = spm_versions.get(repository_ctx)
     if not versions.is_at_least(threshold = min_spm_ver, version = spm_ver):
         fail("""\
-        `rules_spm` requires that Swift Package Manager be version %s or \
-        higher. Found version %s installed.\
-        """ % (min_spm_ver, spm_ver))
+`rules_spm` requires that Swift Package Manager be version %s or \
+higher. Found version %s installed.\
+""" % (min_spm_ver, spm_ver))
 
 def _spm_repositories_impl(repository_ctx):
     # Check for minimum version of SPM

--- a/spm/internal/spm_repositories.bzl
+++ b/spm/internal/spm_repositories.bzl
@@ -5,6 +5,7 @@ load(":packages.bzl", "packages")
 load(":references.bzl", ref_types = "reference_types", refs = "references")
 load(":spm_common.bzl", "spm_common")
 load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@bazel_skylib//lib:versions.bzl", "versions")
 
 # MARK: - File Listing Functions
 
@@ -622,7 +623,17 @@ def _prepare_local_package(repository_ctx, pkg):
 
     return packages.copy(pkg, path = path)
 
+def _check_spm_version(repository_ctx):
+    version_result = repository_ctx.execute(["swift", "package", "--version"])
+    if version_result.return_code != 0:
+        fail("Failed to retrieve the version for Swift Package Manager. %s" % (version_result.stderr))
+
+    # Need to parse the version number Swift Package Manager - Swift 5.4.0
+
 def _spm_repositories_impl(repository_ctx):
+    # Check for minimum version of SPM
+    _check_spm_version(repository_ctx)
+
     orig_pkgs = [packages.from_json(j) for j in repository_ctx.attr.dependencies]
 
     # Prepare local packages

--- a/spm/internal/spm_repositories.bzl
+++ b/spm/internal/spm_repositories.bzl
@@ -4,6 +4,7 @@ load(":package_descriptions.bzl", "module_types", pds = "package_descriptions")
 load(":packages.bzl", "packages")
 load(":references.bzl", ref_types = "reference_types", refs = "references")
 load(":spm_common.bzl", "spm_common")
+load(":spm_versions.bzl", "spm_versions")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:versions.bzl", "versions")
 
@@ -624,11 +625,13 @@ def _prepare_local_package(repository_ctx, pkg):
     return packages.copy(pkg, path = path)
 
 def _check_spm_version(repository_ctx):
-    version_result = repository_ctx.execute(["swift", "package", "--version"])
-    if version_result.return_code != 0:
-        fail("Failed to retrieve the version for Swift Package Manager. %s" % (version_result.stderr))
-
-    # Need to parse the version number Swift Package Manager - Swift 5.4.0
+    min_spm_ver = "5.4.0"
+    spm_ver = spm_versions.get(repository_ctx)
+    if not versions.is_at_least(threshold = min_spm_ver, version = spm_ver):
+        fail("""\
+        `rules_spm` requires that Swift Package Manager be version %s or \
+        higher. Found version %s installed.\
+        """ % (min_spm_ver, spm_ver))
 
 def _spm_repositories_impl(repository_ctx):
     # Check for minimum version of SPM

--- a/spm/internal/spm_versions.bzl
+++ b/spm/internal/spm_versions.bzl
@@ -1,0 +1,13 @@
+def _extract_version(version):
+    # Need to parse the version number from `Swift Package Manager - Swift 5.4.0`
+    for i in range(len(version)):
+        c = version[i]
+        if c.isdigit():
+            return version[i:]
+
+def _get_version(repository_ctx):
+    version_result = repository_ctx.execute(["swift", "package", "--version"])
+    if version_result.return_code != 0:
+        fail("Failed to retrieve the version for Swift Package Manager. %s" % (version_result.stderr))
+
+    return _extract_version(version_result.stdout)

--- a/spm/internal/spm_versions.bzl
+++ b/spm/internal/spm_versions.bzl
@@ -11,3 +11,8 @@ def _get_version(repository_ctx):
         fail("Failed to retrieve the version for Swift Package Manager. %s" % (version_result.stderr))
 
     return _extract_version(version_result.stdout)
+
+spm_versions = struct(
+    extract = _extract_version,
+    get = _get_version,
+)

--- a/spm/internal/spm_versions.bzl
+++ b/spm/internal/spm_versions.bzl
@@ -8,8 +8,9 @@ def _extract_version(version):
 def _get_version(repository_ctx):
     version_result = repository_ctx.execute(["swift", "package", "--version"])
     if version_result.return_code != 0:
-        fail("Failed to retrieve the version for Swift Package Manager. %s" % (version_result.stderr))
-
+        fail("Failed to retrieve the version for Swift Package Manager. %s" % (
+            version_result.stderr
+        ))
     return _extract_version(version_result.stdout)
 
 spm_versions = struct(

--- a/spm/internal/spm_versions.bzl
+++ b/spm/internal/spm_versions.bzl
@@ -1,4 +1,16 @@
 def _extract_version(version):
+    """From a raw version string, extract the semantic version number.
+
+    Input: `Swift Package Manager - Swift 5.4.0`
+    Output: `5.4.0`
+
+    Args:
+        version: A `string` which has the semantic version embedded at the end.
+
+    Returns:
+        A `string` representing the semantic version.
+    """
+
     # Need to parse the version number from `Swift Package Manager - Swift 5.4.0`
     for i in range(len(version)):
         c = version[i]
@@ -6,6 +18,17 @@ def _extract_version(version):
             return version[i:]
 
 def _get_version(repository_ctx):
+    """Returns the semantic version for Swit Package Manager.
+
+    This is equivalent to running `swift package --version` and returning
+    the semantic version.
+
+    Args:
+        repository_ctx: A `repository_ctx` instance.
+
+    Returns:
+        A `string` representing the semantic version for Swift Package Manager.
+    """
     version_result = repository_ctx.execute(["swift", "package", "--version"])
     if version_result.return_code != 0:
         fail("Failed to retrieve the version for Swift Package Manager. %s" % (

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -6,6 +6,7 @@ load(":references_tests.bzl", "references_test_suite")
 load(":platforms_tests.bzl", "platforms_test_suite")
 load(":swift_toolchains_tests.bzl", "swift_toolchains_test_suite")
 load(":spm_package_info_utils_tests.bzl", "spm_package_info_utils_test_suite")
+load(":spm_versions_tests.bzl", "spm_versions_test_suite")
 
 package_descriptions_test_suite()
 
@@ -22,3 +23,5 @@ platforms_test_suite()
 swift_toolchains_test_suite()
 
 spm_package_info_utils_test_suite()
+
+spm_versions_test_suite()

--- a/test/spm_versions_tests.bzl
+++ b/test/spm_versions_tests.bzl
@@ -1,0 +1,16 @@
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+
+def _extract_test(ctx):
+    env = unittest.begin(ctx)
+
+    unittest.fail(env, "IMPLEMENT ME!")
+
+    return unittest.end(env)
+
+extract_test = unittest.make(_extract_test)
+
+def spm_versions_test_suite():
+    return unittest.suite(
+        "spm_versions_tests",
+        extract_test,
+    )

--- a/test/spm_versions_tests.bzl
+++ b/test/spm_versions_tests.bzl
@@ -1,9 +1,12 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//spm/internal:spm_versions.bzl", "spm_versions")
 
 def _extract_test(ctx):
     env = unittest.begin(ctx)
 
-    unittest.fail(env, "IMPLEMENT ME!")
+    raw_str = "Swift Package Manager - Swift 5.4.0"
+    actual = spm_versions.extract(raw_str)
+    asserts.equals(env, "5.4.0", actual)
 
     return unittest.end(env)
 


### PR DESCRIPTION
Closes #61.

`rules_spm` depends upon some flags and JSON features that were added version 5.4.0 of Swift Package Manager. This PR adds a check to be sure that version 5.4.0 or later is found.