### PR TITLE
Make sure that executable targets are named after the product, not the target.

### DIFF
--- a/doc/package_descriptions_api.md
+++ b/doc/package_descriptions_api.md
@@ -285,3 +285,60 @@ Returns all of the targets that are a transitive dependency for the specified pr
 | <a id="package_descriptions.transitive_dependencies-product_refs"></a>product_refs |  A <code>list</code> of reference <code>string</code> values as created by <code>references.create_product_ref()</code>.   |  none |
 
 
+<a id="#package_descriptions.is_executable_product"></a>
+
+## package_descriptions.is_executable_product
+
+<pre>
+package_descriptions.is_executable_product(<a href="#package_descriptions.is_executable_product-product">product</a>)
+</pre>
+
+Returns a boolean indicating whether the specified product dictionary is an executable product.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="package_descriptions.is_executable_product-product"></a>product |  A <code>dict</code> representing a product from package description JSON.   |  none |
+
+
+<a id="#package_descriptions.get_product"></a>
+
+## package_descriptions.get_product
+
+<pre>
+package_descriptions.get_product(<a href="#package_descriptions.get_product-pkg_desc">pkg_desc</a>, <a href="#package_descriptions.get_product-product_name">product_name</a>, <a href="#package_descriptions.get_product-fail_if_not_found">fail_if_not_found</a>)
+</pre>
+
+Returns the product with the specified product name.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="package_descriptions.get_product-pkg_desc"></a>pkg_desc |  A <code>dict</code> representing a package description.   |  none |
+| <a id="package_descriptions.get_product-product_name"></a>product_name |  The product name as a <code>string</code>.   |  none |
+| <a id="package_descriptions.get_product-fail_if_not_found"></a>fail_if_not_found |  <p align="center"> - </p>   |  <code>True</code> |
+
+
+<a id="#package_descriptions.get_product_from_ref"></a>
+
+## package_descriptions.get_product_from_ref
+
+<pre>
+package_descriptions.get_product_from_ref(<a href="#package_descriptions.get_product_from_ref-pkg_descs_dict">pkg_descs_dict</a>, <a href="#package_descriptions.get_product_from_ref-product_ref">product_ref</a>)
+</pre>
+
+Returns the product for the provided reference.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="package_descriptions.get_product_from_ref-pkg_descs_dict"></a>pkg_descs_dict |  A <code>dict</code> where the keys are the package names and the values are package description <code>struct</code> values as returned by <code>package_descriptions.get()</code>.   |  none |
+| <a id="package_descriptions.get_product_from_ref-product_ref"></a>product_ref |  A reference <code>string</code> as created by <code>references.create_product_ref()</code>.   |  none |
+
+

--- a/doc/package_descriptions_api.md
+++ b/doc/package_descriptions_api.md
@@ -323,22 +323,3 @@ Returns the product with the specified product name.
 | <a id="package_descriptions.get_product-fail_if_not_found"></a>fail_if_not_found |  <p align="center"> - </p>   |  <code>True</code> |
 
 
-<a id="#package_descriptions.get_product_from_ref"></a>
-
-## package_descriptions.get_product_from_ref
-
-<pre>
-package_descriptions.get_product_from_ref(<a href="#package_descriptions.get_product_from_ref-pkg_descs_dict">pkg_descs_dict</a>, <a href="#package_descriptions.get_product_from_ref-product_ref">product_ref</a>)
-</pre>
-
-Returns the product for the provided reference.
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="package_descriptions.get_product_from_ref-pkg_descs_dict"></a>pkg_descs_dict |  A <code>dict</code> where the keys are the package names and the values are package description <code>struct</code> values as returned by <code>package_descriptions.get()</code>.   |  none |
-| <a id="package_descriptions.get_product_from_ref-product_ref"></a>product_ref |  A reference <code>string</code> as created by <code>references.create_product_ref()</code>.   |  none |
-
-

--- a/doc/providers.md
+++ b/doc/providers.md
@@ -16,7 +16,7 @@ On this page:
 ## SPMPackageInfo
 
 <pre>
-SPMPackageInfo(<a href="#SPMPackageInfo-name">name</a>, <a href="#SPMPackageInfo-swift_modules">swift_modules</a>, <a href="#SPMPackageInfo-clang_modules">clang_modules</a>, <a href="#SPMPackageInfo-system_library_modules">system_library_modules</a>)
+SPMPackageInfo(<a href="#SPMPackageInfo-name">name</a>, <a href="#SPMPackageInfo-swift_binaries">swift_binaries</a>, <a href="#SPMPackageInfo-swift_modules">swift_modules</a>, <a href="#SPMPackageInfo-clang_modules">clang_modules</a>, <a href="#SPMPackageInfo-system_library_modules">system_library_modules</a>)
 </pre>
 
 Describes the information about an SPM package.
@@ -27,6 +27,7 @@ Describes the information about an SPM package.
 | Name  | Description |
 | :------------- | :------------- |
 | <a id="SPMPackageInfo-name"></a>name |  Name of the Swift package.    |
+| <a id="SPMPackageInfo-swift_binaries"></a>swift_binaries |  A <code>list</code> of values returned from <code>providers.swift_binary</code>.    |
 | <a id="SPMPackageInfo-swift_modules"></a>swift_modules |  A <code>list</code> of values returned from <code>providers.swift_module</code>.    |
 | <a id="SPMPackageInfo-clang_modules"></a>clang_modules |  A <code>list</code> of values returned from <code>providers.clang_module</code>.    |
 | <a id="SPMPackageInfo-system_library_modules"></a>system_library_modules |  <code>List</code> of values returned from <code>providers.system_library_module</code>.    |

--- a/doc/providers_api.md
+++ b/doc/providers_api.md
@@ -42,6 +42,26 @@ Creates a value describing a copy operation.
 | <a id="providers.copy_info-dest"></a>dest |  The destination file.   |  none |
 
 
+<a id="#providers.swift_binary"></a>
+
+## providers.swift_binary
+
+<pre>
+providers.swift_binary(<a href="#providers.swift_binary-name">name</a>, <a href="#providers.swift_binary-executable">executable</a>, <a href="#providers.swift_binary-all_outputs">all_outputs</a>)
+</pre>
+
+Creates a value representing a Swift binary that is built from a package.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="providers.swift_binary-name"></a>name |  Name of the Swift binary.   |  none |
+| <a id="providers.swift_binary-executable"></a>executable |  The executable.   |  <code>None</code> |
+| <a id="providers.swift_binary-all_outputs"></a>all_outputs |  All of the output files that are declared for the module.   |  <code>[]</code> |
+
+
 <a id="#providers.swift_module"></a>
 
 ## providers.swift_module

--- a/doc/references_api.md
+++ b/doc/references_api.md
@@ -103,3 +103,22 @@ Returns a boolean indicating whether the reference string is a target reference.
 | <a id="references.is_target_ref-for_pkg"></a>for_pkg |  Optional. A package name as a <code>string</code> value to include in the check.   |  <code>None</code> |
 
 
+<a id="#references.is_product_ref"></a>
+
+## references.is_product_ref
+
+<pre>
+references.is_product_ref(<a href="#references.is_product_ref-ref_str">ref_str</a>, <a href="#references.is_product_ref-for_pkg">for_pkg</a>)
+</pre>
+
+Returns a boolean indicating whether the reference string is a product reference.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="references.is_product_ref-ref_str"></a>ref_str |  A valid reference <code>string</code>.   |  none |
+| <a id="references.is_product_ref-for_pkg"></a>for_pkg |  Optional. A package name as a <code>string</code> value to include in the check.   |  <code>None</code> |
+
+

--- a/examples/simple_with_binary/BUILD.bazel
+++ b/examples/simple_with_binary/BUILD.bazel
@@ -37,12 +37,11 @@ alias(
     actual = "@swift_utils//SwiftFormat:swiftformat",
 )
 
-# TODO: IMPLEMENT ME!
-# sh_test(
-#     name = "swiftlint_test",
-#     srcs = ["swiftlint_test.sh"],
-#     data = [
-#         ":swiftlint",
-#     ],
-#     deps = ["@bazel_tools//tools/bash/runfiles"],
-# )
+sh_test(
+    name = "swiftformat_test",
+    srcs = ["swiftformat_test.sh"],
+    data = [
+        ":swiftformat",
+    ],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)

--- a/examples/simple_with_binary/BUILD.bazel
+++ b/examples/simple_with_binary/BUILD.bazel
@@ -30,3 +30,19 @@ sh_test(
     ],
     deps = ["@bazel_tools//tools/bash/runfiles"],
 )
+
+# Make sure that the binary is referenced. Otherwise, Bazel won't build it.
+alias(
+    name = "swiftformat",
+    actual = "@swift_utils//SwiftFormat:swiftformat",
+)
+
+# TODO: IMPLEMENT ME!
+# sh_test(
+#     name = "swiftlint_test",
+#     srcs = ["swiftlint_test.sh"],
+#     data = [
+#         ":swiftlint",
+#     ],
+#     deps = ["@bazel_tools//tools/bash/runfiles"],
+# )

--- a/examples/simple_with_binary/WORKSPACE
+++ b/examples/simple_with_binary/WORKSPACE
@@ -55,6 +55,13 @@ spm_repositories(
             from_version = "0.0.0",
             products = ["swiftlint"],
         ),
+        spm_pkg(
+            "https://github.com/nicklockwood/SwiftFormat.git",
+            from_version = "0.0.0",
+            products = [
+                "swiftformat",
+            ],
+        ),
     ],
     platforms = [
         ".macOS(.v10_12)",

--- a/examples/simple_with_binary/swiftformat_test.sh
+++ b/examples/simple_with_binary/swiftformat_test.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+swiftformat="$(rlocation "swift_utils/SwiftFormat/swiftformat")"
+
+# Make sure that we can execute swiftformat.
+"${swiftformat}" --version

--- a/spm/internal/package_descriptions.bzl
+++ b/spm/internal/package_descriptions.bzl
@@ -128,6 +128,18 @@ def _get_package_description(repository_ctx, working_directory = ""):
 
 # MARK: - Product Functions
 
+def _is_executable_product(product):
+    """Returns a boolean indicating whether the specified product dictionary is an executable product.
+
+    Args:
+        product: A `dict` representing a product from package description
+                 JSON.
+
+    Returns:
+        A `bool` indicating whether the product is an executable.
+    """
+    return "executable" in product["type"]
+
 def _is_library_product(product):
     """Returns a boolean indicating whether the specified product dictionary is a library product.
 
@@ -162,6 +174,23 @@ def _get_product(pkg_desc, product_name, fail_if_not_found = True):
         A `dict` representing the desired product.
     """
     return _find_in_list_of_dicts(pkg_desc["products"], "name", product_name, fail_if_not_found = fail_if_not_found)
+
+def _get_product_from_ref(pkg_descs_dict, product_ref):
+    """Returns the product for the provided reference.
+
+    Args:
+        pkg_descs_dict: A `dict` where the keys are the package names and the
+                        values are package description `struct` values as
+                        returned by `package_descriptions.get()`.
+        product_ref: A reference `string` as created by
+                    `references.create_product_ref()`.
+
+    Returns:
+        A `dict` representing the desired product.
+    """
+    ref_type, pkg_name, product_name = refs.split(product_ref)
+    pkg_desc = pkg_descs_dict[pkg_name]
+    return _get_product(pkg_desc, product_name)
 
 # MARK: - Target Functions
 
@@ -373,8 +402,7 @@ def _get_product_target_refs(pkg_descs_dict, product_ref):
         A `list` of target reference `string` values.
     """
     ref_type, pkg_name, product_name = refs.split(product_ref)
-    pkg_desc = pkg_descs_dict[pkg_name]
-    product = _get_product(pkg_desc, product_name)
+    product = _get_product_from_ref(pkg_descs_dict, product_ref)
     return [refs.create(ref_types.target, pkg_name, t) for t in product["targets"]]
 
 def _transitive_dependencies(pkg_descs_dict, product_refs):
@@ -525,6 +553,10 @@ package_descriptions = struct(
     dependency_repository_name = _dependency_repository_name,
     # Transitive Dependency Functions
     transitive_dependencies = _transitive_dependencies,
+    # Product Functions
+    is_executable_product = _is_executable_product,
+    get_product = _get_product,
+    get_product_from_ref = _get_product_from_ref,
     # Constants
     root_pkg_name = "_root",
 )

--- a/spm/internal/package_descriptions.bzl
+++ b/spm/internal/package_descriptions.bzl
@@ -175,23 +175,6 @@ def _get_product(pkg_desc, product_name, fail_if_not_found = True):
     """
     return _find_in_list_of_dicts(pkg_desc["products"], "name", product_name, fail_if_not_found = fail_if_not_found)
 
-def _get_product_from_ref(pkg_descs_dict, product_ref):
-    """Returns the product for the provided reference.
-
-    Args:
-        pkg_descs_dict: A `dict` where the keys are the package names and the
-                        values are package description `struct` values as
-                        returned by `package_descriptions.get()`.
-        product_ref: A reference `string` as created by
-                    `references.create_product_ref()`.
-
-    Returns:
-        A `dict` representing the desired product.
-    """
-    ref_type, pkg_name, product_name = refs.split(product_ref)
-    pkg_desc = pkg_descs_dict[pkg_name]
-    return _get_product(pkg_desc, product_name)
-
 # MARK: - Target Functions
 
 def _is_library_target(target):
@@ -402,7 +385,8 @@ def _get_product_target_refs(pkg_descs_dict, product_ref):
         A `list` of target reference `string` values.
     """
     ref_type, pkg_name, product_name = refs.split(product_ref)
-    product = _get_product_from_ref(pkg_descs_dict, product_ref)
+    pkg_desc = pkg_descs_dict[pkg_name]
+    product = _get_product(pkg_desc, product_name)
     return [refs.create(ref_types.target, pkg_name, t) for t in product["targets"]]
 
 def _transitive_dependencies(pkg_descs_dict, product_refs):

--- a/spm/internal/package_descriptions.bzl
+++ b/spm/internal/package_descriptions.bzl
@@ -556,7 +556,6 @@ package_descriptions = struct(
     # Product Functions
     is_executable_product = _is_executable_product,
     get_product = _get_product,
-    get_product_from_ref = _get_product_from_ref,
     # Constants
     root_pkg_name = "_root",
 )

--- a/spm/internal/providers.bzl
+++ b/spm/internal/providers.bzl
@@ -46,7 +46,7 @@ SPMPackageInfo = provider(
     },
 )
 
-def _create_swift_binary(name, executable, all_outputs):
+def _create_swift_binary(name, executable = None, all_outputs = []):
     """Creates a value representing a Swift binary that is built from a package.
 
     Args:

--- a/spm/internal/providers.bzl
+++ b/spm/internal/providers.bzl
@@ -39,11 +39,29 @@ SPMPackageInfo = provider(
     doc = "Describes the information about an SPM package.",
     fields = {
         "name": "Name of the Swift package.",
+        "swift_binaries": "A `list` of values returned from `providers.swift_binary`.",
         "swift_modules": "A `list` of values returned from `providers.swift_module`.",
         "clang_modules": "A `list` of values returned from `providers.clang_module`.",
         "system_library_modules": "`List` of values returned from `providers.system_library_module`.",
     },
 )
+
+def _create_swift_binary(name, executable, all_outputs):
+    """Creates a value representing a Swift binary that is built from a package.
+
+    Args:
+        name: Name of the Swift binary.
+        executable: The executable.
+        all_outputs: All of the output files that are declared for the module.
+
+    Returns:
+        A struct which provides info about a Swift binary built by SPM.
+    """
+    return struct(
+        name = name,
+        executable = executable,
+        all_outputs = all_outputs,
+    )
 
 def _create_swift_module(
         module_name,
@@ -149,6 +167,7 @@ def _create_copy_info(src, dest):
 providers = struct(
     clang_module = _create_clang_module,
     copy_info = _create_copy_info,
+    swift_binary = _create_swift_binary,
     swift_module = _create_swift_module,
     system_library_module = _create_system_library_module,
 )

--- a/spm/internal/references.bzl
+++ b/spm/internal/references.bzl
@@ -86,6 +86,23 @@ def _is_target_ref(ref_str, for_pkg = None):
         starts_with_parts.extend([for_pkg, "/"])
     return ref_str.startswith("".join(starts_with_parts))
 
+def _is_product_ref(ref_str, for_pkg = None):
+    """Returns a boolean indicating whether the reference string is a product reference.
+
+    Args:
+       ref_str: A valid reference `string`.
+       for_pkg: Optional. A package name as a `string` value to include in
+                the check.
+
+    Returns:
+        A `bool` value indicating whether the reference string is a product
+        reference.
+    """
+    starts_with_parts = [reference_types.product, ":"]
+    if for_pkg != None:
+        starts_with_parts.extend([for_pkg, "/"])
+    return ref_str.startswith("".join(starts_with_parts))
+
 # MARK: - Namespace
 
 reference_types = struct(
@@ -99,4 +116,5 @@ references = struct(
     create_target_ref = _create_target_ref,
     create_product_ref = _create_product_ref,
     is_target_ref = _is_target_ref,
+    is_product_ref = _is_product_ref,
 )

--- a/spm/internal/spm_package.bzl
+++ b/spm/internal/spm_package.bzl
@@ -48,14 +48,11 @@ def _declare_swift_library_target_files(ctx, target, build_config_path):
         all_outputs = all_build_outs,
     )
 
-def _declare_swift_executable_target_files(ctx, target, build_config_path):
-    target_name = target["name"]
-    module_name = target["name"]
-
-    executable = ctx.actions.declare_file("%s/%s" % (build_config_path, target_name))
-
-    return providers.swift_module(
-        module_name = module_name,
+def _declare_swift_executable_product_files(ctx, product, build_config_path):
+    product_name = product["name"]
+    executable = ctx.actions.declare_file("%s/%s" % (build_config_path, product_name))
+    return providers.swift_binary(
+        name = product_name,
         executable = executable,
         all_outputs = [executable],
     )
@@ -158,6 +155,7 @@ def _gather_package_build_info(
         build_config_path,
         clang_custom_infos_dict,
         pkg_desc,
+        product_refs,
         target_refs):
     """Gathers build information for a Swift package.
 
@@ -168,6 +166,7 @@ def _gather_package_build_info(
                                  for this package and the values are a `list`
                                  of public headers.
         pkg_desc: A `dict` representing the package descprtion JSON.
+        product_refs: A `list` of product references (`string`) for this package.
         target_refs: A `list` of target references (`string`) that are
                      dependencies for the package.
 
@@ -176,10 +175,29 @@ def _gather_package_build_info(
         the build information for the Swift package.
     """
     build_outs = []
+    swift_binaries = []
     swift_modules = []
     clang_modules = []
     system_library_modules = []
     pkg_name = pkg_desc["name"]
+
+    # Collect the executable products
+    exec_products = []
+    for product_ref in product_refs:
+        ref_type, pkg_name, product_name = refs.split(product_ref)
+        product = pds.get_product(pkg_desc, product_name)
+        if pds.is_executable_product(product):
+            exec_products.append(product)
+
+    # Declare the outputs for all of the Swift binaries
+    for product in exec_products:
+        swift_binary_info = _declare_swift_executable_product_files(
+            ctx,
+            product,
+            build_config_path,
+        )
+        swift_binaries.append(swift_binary_info)
+        build_outs.extend(swift_binary_info.all_outputs)
 
     # Declare outputs for the targets that will be used
     for target_ref in target_refs:
@@ -196,13 +214,8 @@ def _gather_package_build_info(
                 swift_modules.append(swift_module_info)
                 build_outs.extend(swift_module_info.all_outputs)
             elif pds.is_executable_target(target):
-                swift_module_info = _declare_swift_executable_target_files(
-                    ctx,
-                    target,
-                    build_config_path,
-                )
-                swift_modules.append(swift_module_info)
-                build_outs.extend(swift_module_info.all_outputs)
+                pass
+
             else:
                 fail("Unrecognized Swift target type. %s" % (target))
 
@@ -230,6 +243,7 @@ def _gather_package_build_info(
 
     pkg_info = SPMPackageInfo(
         name = pkg_name,
+        swift_binaries = swift_binaries,
         swift_modules = swift_modules,
         clang_modules = clang_modules,
         system_library_modules = system_library_modules,
@@ -478,11 +492,13 @@ def _spm_package_impl(ctx):
             continue
         pkg_desc = pkg_descs_dict[pkg_name]
         clang_custom_infos_dict = pkg_clang_custom_infos_dict.get(pkg_name, default = {})
+        product_refs = [pr for pr in declared_product_refs if refs.is_product_ref(pr, for_pkg = pkg_name)]
         pkg_build_infos_dict[pkg_name] = _gather_package_build_info(
             ctx,
             build_config_path,
             clang_custom_infos_dict,
             pkg_desc,
+            product_refs,
             target_refs,
         )
 

--- a/spm/internal/spm_package.bzl
+++ b/spm/internal/spm_package.bzl
@@ -214,6 +214,7 @@ def _gather_package_build_info(
                 swift_modules.append(swift_module_info)
                 build_outs.extend(swift_module_info.all_outputs)
             elif pds.is_executable_target(target):
+                # Executable targets are declared by product, not by SPM target.
                 pass
 
             else:

--- a/spm/internal/spm_package_info_utils.bzl
+++ b/spm/internal/spm_package_info_utils.bzl
@@ -27,6 +27,9 @@ def _get_module_info(pkg_info, module_name):
         module a `struct` value as created by `providers.clang_module()` is
         returned.
     """
+    for binary in pkg_info.swift_binaries:
+        if binary.name == module_name:
+            return binary
     for module in pkg_info.swift_modules:
         if module.module_name == module_name:
             return module

--- a/spm/internal/spm_repositories.bzl
+++ b/spm/internal/spm_repositories.bzl
@@ -239,11 +239,6 @@ def _generate_bazel_pkg(
     pkg_name = pkg_desc["name"]
     bld_path = "%s/BUILD.bazel" % (pkg_name)
 
-    # DEBUG BEGIN
-    # prds = [pds.get_product_from_ref()]
-    # exec_product_refs = [pr for pr in declared_product_refs if pds.is_]
-    # DEBUG END
-
     module_decls = []
 
     # Create a binary target for the executable products

--- a/spm/internal/spm_repositories.bzl
+++ b/spm/internal/spm_repositories.bzl
@@ -233,6 +233,8 @@ def _generate_bazel_pkg(
                          public header path `string` values and the keys are
                          a `string` created by
                          `spm_common.create_clang_hdrs_key()`.
+        exec_products: A `list` of product `dict` from the package description
+                       that are executable.
         pkg_root_path: A path `string` specifying the location of the package
                        which defines the target.
     """
@@ -617,14 +619,6 @@ def _configure_spm_repository(repository_ctx, pkgs):
         if pds.is_executable_product(product):
             exec_products.append(product)
             exec_products_dict[pkg_name] = exec_products
-
-    # DEBUG BEGIN
-    print("*** CHUCK declared_product_refs: ", declared_product_refs)
-    print("*** CHUCK exec_products_dict: ")
-    for key in exec_products_dict:
-        print("*** CHUCK", key, ":", exec_products_dict[key])
-
-    # DEBUG END
 
     dep_target_refs_dict = pds.transitive_dependencies(pkg_descs_dict, declared_product_refs)
     for pkg_name in pkg_descs_dict:

--- a/spm/internal/spm_swift_binary.bzl
+++ b/spm/internal/spm_swift_binary.bzl
@@ -25,17 +25,17 @@ def _spm_swift_binary_impl(ctx):
         module_name = ctx.attr.name
 
     pkg_info = spm_package_info_utils.get(pkgs_info.packages, pkg_name)
-    module_info = spm_package_info_utils.get_module_info(pkg_info, module_name)
+    binary_info = spm_package_info_utils.get_module_info(pkg_info, module_name)
 
-    if module_info.executable == None:
+    if binary_info.executable == None:
         fail("The specified module (%s) is not executable." % (module_name))
 
     # Bazel will error if we try to return a file that we did not create as
     # the executable. So, we symlink it.
-    executable = ctx.actions.declare_file(module_info.executable.basename)
+    executable = ctx.actions.declare_file(binary_info.executable.basename)
     ctx.actions.symlink(
         output = executable,
-        target_file = module_info.executable,
+        target_file = binary_info.executable,
     )
 
     return [

--- a/test/package_descriptions_tests.bzl
+++ b/test/package_descriptions_tests.bzl
@@ -17,6 +17,26 @@ def _parse_json_test(ctx):
 
 parse_json_test = unittest.make(_parse_json_test)
 
+def _get_product_test(ctx):
+    env = unittest.begin(ctx)
+
+    pkg_desc = {
+        "products": [
+            {"name": "Foo", "type": {"library": {}}},
+            {"name": "Chicken", "type": {"executable": None}},
+            {"name": "Bar", "type": {"library": {}}},
+        ],
+    }
+    result = pds.get_product(pkg_desc, "Foo")
+    asserts.equals(env, "Foo", result["name"])
+
+    result = pds.get_product(pkg_desc, "Chicken")
+    asserts.equals(env, "Chicken", result["name"])
+
+    return unittest.end(env)
+
+get_product_test = unittest.make(_get_product_test)
+
 def _is_executable_product_test(ctx):
     env = unittest.begin(ctx)
 
@@ -303,6 +323,7 @@ def package_descriptions_test_suite():
     unittest.suite(
         "package_description_tests",
         parse_json_test,
+        get_product_test,
         is_executable_product_test,
         is_library_product_test,
         library_products_test,

--- a/test/package_descriptions_tests.bzl
+++ b/test/package_descriptions_tests.bzl
@@ -17,6 +17,18 @@ def _parse_json_test(ctx):
 
 parse_json_test = unittest.make(_parse_json_test)
 
+def _is_executable_product_test(ctx):
+    env = unittest.begin(ctx)
+
+    product = {"type": {"library": {}}}
+    asserts.false(env, pds.is_executable_product(product))
+    product = {"type": {"executable": None}}
+    asserts.true(env, pds.is_executable_product(product))
+
+    return unittest.end(env)
+
+is_executable_product_test = unittest.make(_is_executable_product_test)
+
 def _is_library_product_test(ctx):
     env = unittest.begin(ctx)
 
@@ -291,6 +303,7 @@ def package_descriptions_test_suite():
     unittest.suite(
         "package_description_tests",
         parse_json_test,
+        is_executable_product_test,
         is_library_product_test,
         library_products_test,
         is_library_target_test,

--- a/test/providers_tests.bzl
+++ b/test/providers_tests.bzl
@@ -1,6 +1,25 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//spm/internal:providers.bzl", "providers")
 
+def _swift_binary_test(ctx):
+    env = unittest.begin(ctx)
+
+    result = providers.swift_binary(
+        "MyBinary",
+        executable = "exec",
+        all_outputs = ["all"],
+    )
+    expected = struct(
+        name = "MyBinary",
+        executable = "exec",
+        all_outputs = ["all"],
+    )
+    asserts.equals(env, expected, result)
+
+    return unittest.end(env)
+
+swift_binary_test = unittest.make(_swift_binary_test)
+
 def _swift_module_test(ctx):
     env = unittest.begin(ctx)
 
@@ -103,6 +122,7 @@ system_library_module_test = unittest.make(_system_library_module_test)
 def providers_test_suite():
     return unittest.suite(
         "providers_tests",
+        swift_binary_test,
         swift_module_test,
         clang_module_test,
         copy_info_test,

--- a/test/references_tests.bzl
+++ b/test/references_tests.bzl
@@ -67,6 +67,25 @@ def _is_target_ref_test(ctx):
 
 is_target_ref_test = unittest.make(_is_target_ref_test)
 
+def _is_product_ref_test(ctx):
+    env = unittest.begin(ctx)
+
+    ref = references.create(reference_types.product, "foo-kit", "FooKit")
+    asserts.true(env, references.is_product_ref(ref))
+
+    ref = references.create(reference_types.target, "foo-kit", "FooKit")
+    asserts.false(env, references.is_product_ref(ref))
+
+    ref = references.create(reference_types.product, "foo-kit", "FooKit")
+    asserts.true(env, references.is_product_ref(ref, for_pkg = "foo-kit"))
+
+    ref = references.create(reference_types.product, "foo-kit", "FooKit")
+    asserts.false(env, references.is_product_ref(ref, for_pkg = "bar-kit"))
+
+    return unittest.end(env)
+
+is_product_ref_test = unittest.make(_is_product_ref_test)
+
 def references_test_suite():
     return unittest.suite(
         "references_tests",
@@ -75,4 +94,5 @@ def references_test_suite():
         create_product_ref_test,
         create_target_ref_test,
         is_target_ref_test,
+        is_product_ref_test,
     )

--- a/test/spm_package_info_utils_tests.bzl
+++ b/test/spm_package_info_utils_tests.bzl
@@ -8,12 +8,14 @@ def _get_test(ctx):
     pkg_infos = [
         SPMPackageInfo(
             name = "hello",
+            swift_binaries = [],
             swift_modules = [],
             clang_modules = [],
             system_library_modules = [],
         ),
         SPMPackageInfo(
             name = "goodbye",
+            swift_binaries = [],
             swift_modules = [],
             clang_modules = [],
             system_library_modules = [],
@@ -33,6 +35,10 @@ def _get_module_info_test(ctx):
 
     pkg_info = SPMPackageInfo(
         name = "hello",
+        swift_binaries = [
+            providers.swift_binary("MySwiftBinary"),
+            providers.swift_binary("NotMySwiftBinary"),
+        ],
         swift_modules = [
             providers.swift_module("MySwift"),
             providers.swift_module("NotMySwift"),
@@ -46,6 +52,9 @@ def _get_module_info_test(ctx):
             providers.system_library_module("NotMySystem"),
         ],
     )
+
+    result = spm_package_info_utils.get_module_info(pkg_info, "MySwiftBinary")
+    asserts.equals(env, "MySwiftBinary", result.name)
 
     result = spm_package_info_utils.get_module_info(pkg_info, "MySwift")
     asserts.equals(env, "MySwift", result.module_name)


### PR DESCRIPTION
Closes #77.