### PR TITLE
Migrate from `rules_bzlformat`, `rules_updatesrc`, and `bazel_shlib` to `bazel-starlib`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_missing_pkgs", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_missing_pkgs", "bzlformat_pkg")
 load(
-    "@cgrindel_rules_updatesrc//updatesrc:updatesrc.bzl",
+    "@cgrindel_bazel_starlib//updatesrc:defs.bzl",
     "updatesrc_update_all",
 )
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,25 +22,17 @@ load(
 
 swift_rules_extra_dependencies()
 
+load("@cgrindel_bazel_starlib//:deps.bzl", "bazel_starlib_dependencies")
+
+bazel_starlib_dependencies()
+
 # MARK: - Documentation
-
-load("@cgrindel_bazel_doc//bazeldoc:deps.bzl", "bazeldoc_dependencies")
-
-bazeldoc_dependencies()
 
 load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
 
 stardoc_repositories()
 
-# MARK: - rules_bzlformat
-
-load("@cgrindel_rules_bzlformat//bzlformat:deps.bzl", "bzlformat_rules_dependencies")
-
-bzlformat_rules_dependencies()
-
-load("@cgrindel_bazel_starlib//:deps.bzl", "bazel_starlib_dependencies")
-
-bazel_starlib_dependencies()
+# MARK: - Buildifier
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,6 +8,10 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
 
+load("@cgrindel_bazel_starlib//:deps.bzl", "bazel_starlib_dependencies")
+
+bazel_starlib_dependencies()
+
 load(
     "@build_bazel_rules_swift//swift:repositories.bzl",
     "swift_rules_dependencies",
@@ -21,10 +25,6 @@ load(
 )
 
 swift_rules_extra_dependencies()
-
-load("@cgrindel_bazel_starlib//:deps.bzl", "bazel_starlib_dependencies")
-
-bazel_starlib_dependencies()
 
 # MARK: - Documentation
 

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load(
     "@cgrindel_bazel_doc//bazeldoc:bazeldoc.bzl",
     "doc_for_provs",

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load(
     "@cgrindel_rules_bazel_integration_test//bazel_integration_test:bazel_integration_test.bzl",
     "bazel_integration_test",

--- a/examples/ios_sim/WORKSPACE
+++ b/examples/ios_sim/WORKSPACE
@@ -62,13 +62,13 @@ load(
 
 spm_rules_dependencies()
 
-load("@cgrindel_rules_bzlformat//bzlformat:deps.bzl", "bzlformat_rules_dependencies")
-
-bzlformat_rules_dependencies()
-
 load("@cgrindel_bazel_starlib//:deps.bzl", "bazel_starlib_dependencies")
 
 bazel_starlib_dependencies()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
 
 # MARK: - External SPM Packages
 

--- a/examples/local_package/WORKSPACE
+++ b/examples/local_package/WORKSPACE
@@ -34,13 +34,13 @@ load(
 
 spm_rules_dependencies()
 
-load("@cgrindel_rules_bzlformat//bzlformat:deps.bzl", "bzlformat_rules_dependencies")
-
-bzlformat_rules_dependencies()
-
 load("@cgrindel_bazel_starlib//:deps.bzl", "bazel_starlib_dependencies")
 
 bazel_starlib_dependencies()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
 
 load("@cgrindel_rules_spm//spm:spm.bzl", "spm_pkg", "spm_repositories")
 

--- a/examples/simple/WORKSPACE
+++ b/examples/simple/WORKSPACE
@@ -14,13 +14,13 @@ load(
 
 spm_rules_dependencies()
 
-load("@cgrindel_rules_bzlformat//bzlformat:deps.bzl", "bzlformat_rules_dependencies")
-
-bzlformat_rules_dependencies()
-
 load("@cgrindel_bazel_starlib//:deps.bzl", "bazel_starlib_dependencies")
 
 bazel_starlib_dependencies()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
 
 load(
     "@build_bazel_rules_swift//swift:repositories.bzl",

--- a/examples/simple_revision/WORKSPACE
+++ b/examples/simple_revision/WORKSPACE
@@ -14,13 +14,13 @@ load(
 
 spm_rules_dependencies()
 
-load("@cgrindel_rules_bzlformat//bzlformat:deps.bzl", "bzlformat_rules_dependencies")
-
-bzlformat_rules_dependencies()
-
 load("@cgrindel_bazel_starlib//:deps.bzl", "bazel_starlib_dependencies")
 
 bazel_starlib_dependencies()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
 
 load(
     "@build_bazel_rules_swift//swift:repositories.bzl",

--- a/examples/simple_with_binary/WORKSPACE
+++ b/examples/simple_with_binary/WORKSPACE
@@ -14,13 +14,13 @@ load(
 
 spm_rules_dependencies()
 
-load("@cgrindel_rules_bzlformat//bzlformat:deps.bzl", "bzlformat_rules_dependencies")
-
-bzlformat_rules_dependencies()
-
 load("@cgrindel_bazel_starlib//:deps.bzl", "bazel_starlib_dependencies")
 
 bazel_starlib_dependencies()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
 
 load(
     "@build_bazel_rules_swift//swift:repositories.bzl",

--- a/examples/simple_with_dev_dir/WORKSPACE
+++ b/examples/simple_with_dev_dir/WORKSPACE
@@ -14,13 +14,13 @@ load(
 
 spm_rules_dependencies()
 
-load("@cgrindel_rules_bzlformat//bzlformat:deps.bzl", "bzlformat_rules_dependencies")
-
-bzlformat_rules_dependencies()
-
 load("@cgrindel_bazel_starlib//:deps.bzl", "bazel_starlib_dependencies")
 
 bazel_starlib_dependencies()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
 
 load(
     "@build_bazel_rules_swift//swift:repositories.bzl",

--- a/examples/vapor/WORKSPACE
+++ b/examples/vapor/WORKSPACE
@@ -16,13 +16,13 @@ load(
 
 spm_rules_dependencies()
 
-load("@cgrindel_rules_bzlformat//bzlformat:deps.bzl", "bzlformat_rules_dependencies")
-
-bzlformat_rules_dependencies()
-
 load("@cgrindel_bazel_starlib//:deps.bzl", "bazel_starlib_dependencies")
 
 bazel_starlib_dependencies()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
 
 load(
     "@build_bazel_rules_swift//swift:repositories.bzl",

--- a/spm/BUILD.bazel
+++ b/spm/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 package(default_visibility = ["//visibility:public"])

--- a/spm/internal/BUILD.bazel
+++ b/spm/internal/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 exports_files(

--- a/spm/internal/modulemap_parser/BUILD.bazel
+++ b/spm/internal/modulemap_parser/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 bzl_library(

--- a/spm/internal/repositories.bzl
+++ b/spm/internal/repositories.bzl
@@ -21,20 +21,12 @@ def spm_rules_dependencies():
         url = "https://github.com/bazelbuild/rules_swift/releases/download/0.24.0/rules_swift.0.24.0.tar.gz",
     )
 
-    maybe(
-        http_archive,
-        name = "cgrindel_bazel_doc",
-        sha256 = "3ccc6d205a7f834c5e89adcb4bc5091a9a07a69376107807eb9aea731ce92854",
-        strip_prefix = "bazel-doc-0.1.2",
-        urls = ["https://github.com/cgrindel/bazel-doc/archive/v0.1.2.tar.gz"],
-    )
+    # TODO: FIX ME
 
     maybe(
-        http_archive,
-        name = "cgrindel_rules_bzlformat",
-        sha256 = "44b09ad9c5395760065820676ba6e65efec08ae02c1ce7e2d39d42c5b1e7aec8",
-        strip_prefix = "rules_bzlformat-0.2.1",
-        urls = ["https://github.com/cgrindel/rules_bzlformat/archive/v0.2.1.tar.gz"],
+        native.local_repository,
+        name = "cgrindel_bazel_starlib",
+        path = "/Users/chuck/code/cgrindel/bazel-starlib",
     )
 
     maybe(

--- a/spm/internal/repositories.bzl
+++ b/spm/internal/repositories.bzl
@@ -21,12 +21,14 @@ def spm_rules_dependencies():
         url = "https://github.com/bazelbuild/rules_swift/releases/download/0.24.0/rules_swift.0.24.0.tar.gz",
     )
 
-    # TODO: FIX ME
-
     maybe(
-        native.local_repository,
+        http_archive,
         name = "cgrindel_bazel_starlib",
-        path = "/Users/chuck/code/cgrindel/bazel-starlib",
+        sha256 = "238c05abf31447b93bd15b616c7413c4c719ee7b5e81c1489ca20f02ce628489",
+        strip_prefix = "bazel-starlib-0.2.0",
+        urls = [
+            "http://github.com/cgrindel/bazel-starlib/archive/v0.2.0.tar.gz",
+        ],
     )
 
     maybe(

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load(":package_descriptions_tests.bzl", "package_descriptions_test_suite")
 load(":providers_tests.bzl", "providers_test_suite")
 load(":packages_tests.bzl", "packages_test_suite")

--- a/test/modulemap_parser/BUILD.bazel
+++ b/test/modulemap_parser/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load(":declarations_tests.bzl", "declarations_test_suite")
 load(":errors_tests.bzl", "errors_test_suite")
 load(":parser_tests.bzl", "parser_test_suite")


### PR DESCRIPTION
Related to cgrindel/bazel-starlib#44.
