### PR TITLE
Updated `spm_pkg` to accept `exact_version` for a package.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -18,7 +18,6 @@ bzlformat_missing_pkgs(
 updatesrc_update_all(
     name = "update_all",
     targets_to_run = [
-        "//doc:update",
         ":bzlformat_missing_pkgs_fix",
     ],
 )

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ spm_repositories(
     dependencies = [
         spm_pkg(
             "https://github.com/apple/swift-log.git",
-            from_version = "1.0.0",
+            exact_version = "1.4.2",
             products = ["Logging"],
         ),
     ],

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -29,7 +29,7 @@ A package name `string`.
 ## packages.create
 
 <pre>
-packages.create(<a href="#packages.create-url">url</a>, <a href="#packages.create-path">path</a>, <a href="#packages.create-name">name</a>, <a href="#packages.create-from_version">from_version</a>, <a href="#packages.create-revision">revision</a>, <a href="#packages.create-products">products</a>)
+packages.create(<a href="#packages.create-url">url</a>, <a href="#packages.create-path">path</a>, <a href="#packages.create-name">name</a>, <a href="#packages.create-exact_version">exact_version</a>, <a href="#packages.create-from_version">from_version</a>, <a href="#packages.create-revision">revision</a>, <a href="#packages.create-products">products</a>)
 </pre>
 
 Create a Swift package dependency struct.
@@ -48,6 +48,7 @@ https://docs.swift.org/package-manager/PackageDescription/PackageDescription.htm
 | <a id="packages.create-url"></a>url |  A <code>string</code> representing the URL for the package repository.   |  <code>None</code> |
 | <a id="packages.create-path"></a>path |  A local path <code>string</code> to the package repository.   |  <code>None</code> |
 | <a id="packages.create-name"></a>name |  Optional. The name (<code>string</code>) to be used for the package in Package.swift.   |  <code>None</code> |
+| <a id="packages.create-exact_version"></a>exact_version |  Optional. A <code>string</code> representing a valid "exact" SPM version.   |  <code>None</code> |
 | <a id="packages.create-from_version"></a>from_version |  Optional. A <code>string</code> representing a valid "from" SPM version.   |  <code>None</code> |
 | <a id="packages.create-revision"></a>revision |  Optional. A commit hash (<code>string</code>).   |  <code>None</code> |
 | <a id="packages.create-products"></a>products |  A <code>list</code> of <code>string</code> values representing the names of the products to be used.   |  <code>[]</code> |
@@ -62,7 +63,7 @@ A `struct` representing a Swift package.
 ## packages.copy
 
 <pre>
-packages.copy(<a href="#packages.copy-pkg">pkg</a>, <a href="#packages.copy-url">url</a>, <a href="#packages.copy-path">path</a>, <a href="#packages.copy-name">name</a>, <a href="#packages.copy-from_version">from_version</a>, <a href="#packages.copy-revision">revision</a>, <a href="#packages.copy-products">products</a>)
+packages.copy(<a href="#packages.copy-pkg">pkg</a>, <a href="#packages.copy-url">url</a>, <a href="#packages.copy-path">path</a>, <a href="#packages.copy-name">name</a>, <a href="#packages.copy-exact_version">exact_version</a>, <a href="#packages.copy-from_version">from_version</a>, <a href="#packages.copy-revision">revision</a>, <a href="#packages.copy-products">products</a>)
 </pre>
 
 Create a copy of the provided package replacing any of the argument values that are not None.
@@ -76,6 +77,7 @@ Create a copy of the provided package replacing any of the argument values that 
 | <a id="packages.copy-url"></a>url |  Optional. A <code>string</code> representing the URL for the package repository.   |  <code>None</code> |
 | <a id="packages.copy-path"></a>path |  Optional. A local path <code>string</code> to the package repository.   |  <code>None</code> |
 | <a id="packages.copy-name"></a>name |  Optional. The name (<code>string</code>) to be used for the package in Package.swift.   |  <code>None</code> |
+| <a id="packages.copy-exact_version"></a>exact_version |  Optional. A <code>string</code> representing a valid "exact" SPM version.   |  <code>None</code> |
 | <a id="packages.copy-from_version"></a>from_version |  Optional. A <code>string</code> representing a valid "from" SPM version.   |  <code>None</code> |
 | <a id="packages.copy-revision"></a>revision |  Optional. A commit hash (<code>string</code>).   |  <code>None</code> |
 | <a id="packages.copy-products"></a>products |  Optional. jA <code>list</code> of <code>string</code> values representing the names of the products to be used.   |  <code>None</code> |
@@ -90,7 +92,7 @@ A `struct` representing a Swift package.
 ## packages.pkg_json
 
 <pre>
-packages.pkg_json(<a href="#packages.pkg_json-url">url</a>, <a href="#packages.pkg_json-path">path</a>, <a href="#packages.pkg_json-name">name</a>, <a href="#packages.pkg_json-from_version">from_version</a>, <a href="#packages.pkg_json-revision">revision</a>, <a href="#packages.pkg_json-products">products</a>)
+packages.pkg_json(<a href="#packages.pkg_json-url">url</a>, <a href="#packages.pkg_json-path">path</a>, <a href="#packages.pkg_json-name">name</a>, <a href="#packages.pkg_json-exact_version">exact_version</a>, <a href="#packages.pkg_json-from_version">from_version</a>, <a href="#packages.pkg_json-revision">revision</a>, <a href="#packages.pkg_json-products">products</a>)
 </pre>
 
 Returns a JSON string describing a Swift package.
@@ -109,6 +111,7 @@ https://docs.swift.org/package-manager/PackageDescription/PackageDescription.htm
 | <a id="packages.pkg_json-url"></a>url |  A <code>string</code> representing the URL for the package repository.   |  <code>None</code> |
 | <a id="packages.pkg_json-path"></a>path |  A local path <code>string</code> to the package repository.   |  <code>None</code> |
 | <a id="packages.pkg_json-name"></a>name |  Optional. The name (<code>string</code>) to be used for the package in Package.swift.   |  <code>None</code> |
+| <a id="packages.pkg_json-exact_version"></a>exact_version |  Optional. A <code>string</code> representing a valid "exact" SPM version.   |  <code>None</code> |
 | <a id="packages.pkg_json-from_version"></a>from_version |  Optional. A <code>string</code> representing a valid "from" SPM version.   |  <code>None</code> |
 | <a id="packages.pkg_json-revision"></a>revision |  Optional. A commit hash (<code>string</code>).   |  <code>None</code> |
 | <a id="packages.pkg_json-products"></a>products |  A <code>list</code> of <code>string</code> values representing the names of the products to be used.   |  <code>[]</code> |

--- a/doc/workspace_rules_overview.md
+++ b/doc/workspace_rules_overview.md
@@ -41,7 +41,7 @@ Used to fetch and prepare external Swift package manager packages for the build.
 ## spm_pkg
 
 <pre>
-spm_pkg(<a href="#spm_pkg-url">url</a>, <a href="#spm_pkg-path">path</a>, <a href="#spm_pkg-name">name</a>, <a href="#spm_pkg-from_version">from_version</a>, <a href="#spm_pkg-revision">revision</a>, <a href="#spm_pkg-products">products</a>)
+spm_pkg(<a href="#spm_pkg-url">url</a>, <a href="#spm_pkg-path">path</a>, <a href="#spm_pkg-name">name</a>, <a href="#spm_pkg-exact_version">exact_version</a>, <a href="#spm_pkg-from_version">from_version</a>, <a href="#spm_pkg-revision">revision</a>, <a href="#spm_pkg-products">products</a>)
 </pre>
 
 Returns a JSON string describing a Swift package.
@@ -60,6 +60,7 @@ https://docs.swift.org/package-manager/PackageDescription/PackageDescription.htm
 | <a id="spm_pkg-url"></a>url |  A <code>string</code> representing the URL for the package repository.   |  <code>None</code> |
 | <a id="spm_pkg-path"></a>path |  A local path <code>string</code> to the package repository.   |  <code>None</code> |
 | <a id="spm_pkg-name"></a>name |  Optional. The name (<code>string</code>) to be used for the package in Package.swift.   |  <code>None</code> |
+| <a id="spm_pkg-exact_version"></a>exact_version |  Optional. A <code>string</code> representing a valid "exact" SPM version.   |  <code>None</code> |
 | <a id="spm_pkg-from_version"></a>from_version |  Optional. A <code>string</code> representing a valid "from" SPM version.   |  <code>None</code> |
 | <a id="spm_pkg-revision"></a>revision |  Optional. A commit hash (<code>string</code>).   |  <code>None</code> |
 | <a id="spm_pkg-products"></a>products |  A <code>list</code> of <code>string</code> values representing the names of the products to be used.   |  <code>[]</code> |

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,8 +9,8 @@
 
 ## Examples
 
-- [Simple](/examples/simple): Demonstrates how to declare a Swift package as a dependency and use it
-  in a `swift_binary` target.
+- [Simple](/examples/simple): Demonstrates how to declare an exact version of a Swift package as a 
+  dependency and use it in a `swift_binary` target.
 - [Simple (Revision/Commit)](/examples/simple_revision): Same as `Simple`, except the Swift package
   version is specified as a commit hash instead of a [semantic version](https://semver.org/).
 - [Simple + Swift Package Binary](/examples/simple_with_binary): Same as `Simple`. In addition, it

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -1,4 +1,4 @@
 # Simple Example for `rules_spm`
 
-This example demonstrates how to declare a Swift package as a dependency, specify it as a 
-dependency in a `swift_binary` rule and then import it in a Swift source file.
+This example demonstrates how to declare an exact version of a Swift package as a dependency,
+specify it as a dependency in a `swift_binary` rule and then import it in a Swift source file.

--- a/examples/simple/WORKSPACE
+++ b/examples/simple/WORKSPACE
@@ -43,7 +43,7 @@ spm_repositories(
     dependencies = [
         spm_pkg(
             "https://github.com/apple/swift-log.git",
-            from_version = "1.0.0",
+            exact_version = "1.4.2",
             products = ["Logging"],
         ),
     ],

--- a/spm/internal/packages.bzl
+++ b/spm/internal/packages.bzl
@@ -23,6 +23,7 @@ def _create_pkg(
         url = None,
         path = None,
         name = None,
+        exact_version = None,
         from_version = None,
         revision = None,
         products = []):
@@ -38,6 +39,7 @@ def _create_pkg(
         path: A local path `string` to the package repository.
         products: A `list` of `string` values representing the names of the products to be used.
         name: Optional. The name (`string`) to be used for the package in Package.swift.
+        exact_version: Optional. A `string` representing a valid "exact" SPM version.
         from_version: Optional. A `string` representing a valid "from" SPM version.
         revision: Optional. A commit hash (`string`).
 
@@ -57,18 +59,19 @@ def _create_pkg(
         fail("A list of product names from the package must be provided.")
 
     if url != None:
-        dep_requirements = [from_version, revision]
+        dep_requirements = [exact_version, from_version, revision]
         specified_dep_reqs = [d for d in dep_requirements if d != None]
         specified_dep_reqs_cnt = len(specified_dep_reqs)
         if specified_dep_reqs_cnt < 1:
-            fail("A package requirement (e.g. from_version, revision) must be specified.")
+            fail("A package requirement (e.g. exact_version, from_version, revision) must be specified.")
         if specified_dep_reqs_cnt > 1:
-            fail("Only a single package requirement (e.g. from_version, revision) can be specified.")
+            fail("Only a single package requirement (e.g. exact_version, from_version, revision) can be specified.")
 
     return struct(
         url = url,
         path = path,
         name = name,
+        exact_version = exact_version,
         from_version = from_version,
         revision = revision,
         products = products,
@@ -79,6 +82,7 @@ def _copy_pkg(
         url = None,
         path = None,
         name = None,
+        exact_version = None,
         from_version = None,
         revision = None,
         products = None):
@@ -91,6 +95,7 @@ def _copy_pkg(
         products: Optional. jA `list` of `string` values representing the names
                   of the products to be used.
         name: Optional. The name (`string`) to be used for the package in Package.swift.
+        exact_version: Optional. A `string` representing a valid "exact" SPM version.
         from_version: Optional. A `string` representing a valid "from" SPM version.
         revision: Optional. A commit hash (`string`).
 
@@ -101,6 +106,7 @@ def _copy_pkg(
         url = url if url != None else pkg.url,
         path = path if path != None else pkg.path,
         name = name if name != None else pkg.name,
+        exact_version = exact_version if exact_version != None else pkg.exact_version,
         from_version = from_version if from_version != None else pkg.from_version,
         revision = revision if revision != None else pkg.revision,
         products = products if products != None else pkg.products,
@@ -112,6 +118,7 @@ def _to_json(
         url = None,
         path = None,
         name = None,
+        exact_version = None,
         from_version = None,
         revision = None,
         products = []):
@@ -127,6 +134,7 @@ def _to_json(
         path: A local path `string` to the package repository.
         products: A `list` of `string` values representing the names of the products to be used.
         name: Optional. The name (`string`) to be used for the package in Package.swift.
+        exact_version: Optional. A `string` representing a valid "exact" SPM version.
         from_version: Optional. A `string` representing a valid "from" SPM version.
         revision: Optional. A commit hash (`string`).
 
@@ -137,6 +145,7 @@ def _to_json(
         url = url,
         path = path,
         name = name,
+        exact_version = exact_version,
         from_version = from_version,
         revision = revision,
         products = products,

--- a/spm/internal/repositories.bzl
+++ b/spm/internal/repositories.bzl
@@ -24,10 +24,10 @@ def spm_rules_dependencies():
     maybe(
         http_archive,
         name = "cgrindel_bazel_starlib",
-        sha256 = "238c05abf31447b93bd15b616c7413c4c719ee7b5e81c1489ca20f02ce628489",
-        strip_prefix = "bazel-starlib-0.2.0",
+        sha256 = "163a45d949fdb96b328bb44fe56976c610c6728c77118c6cd999f26cedca97eb",
+        strip_prefix = "bazel-starlib-0.2.1",
         urls = [
-            "http://github.com/cgrindel/bazel-starlib/archive/v0.2.0.tar.gz",
+            "http://github.com/cgrindel/bazel-starlib/archive/v0.2.1.tar.gz",
         ],
     )
 

--- a/spm/internal/spm_repositories.bzl
+++ b/spm/internal/spm_repositories.bzl
@@ -491,6 +491,10 @@ _local_package_tpl = """\
 .package(name: "{name}", path: "{path}")\
 """
 
+_package_exact_tpl = """\
+.package(name: "{name}", url: "{url}", .exact("{version}"))\
+"""
+
 _package_from_tpl = """\
 .package(name: "{name}", url: "{url}", from: "{version}")\
 """
@@ -524,6 +528,12 @@ def _generate_spm_package_dep(pkg):
             path = pkg.path,
         )
     if pkg.url != None:
+        if pkg.exact_version:
+            return _package_exact_tpl.format(
+                name = pkg.name,
+                url = pkg.url,
+                version = pkg.exact_version,
+            )
         if pkg.from_version:
             return _package_from_tpl.format(
                 name = pkg.name,

--- a/test/packages_tests.bzl
+++ b/test/packages_tests.bzl
@@ -18,13 +18,27 @@ def _create_test(ctx):
     url = "https://github.com/foo/bar.git"
     path = "/path/to/foo/bar"
     from_version = "1.0.0"
+    exact_version = "1.2.3"
     products = ["Foo", "Bar"]
+
+    actual = packages.create(url = url, exact_version = exact_version, products = products)
+    expected = struct(
+        url = url,
+        path = None,
+        name = packages.create_name(url),
+        exact_version = exact_version,
+        from_version = None,
+        revision = None,
+        products = products,
+    )
+    asserts.equals(env, expected, actual)
 
     actual = packages.create(url = url, from_version = from_version, products = products)
     expected = struct(
         url = url,
         path = None,
         name = packages.create_name(url),
+        exact_version = None,
         from_version = from_version,
         revision = None,
         products = products,
@@ -36,6 +50,7 @@ def _create_test(ctx):
         url = None,
         path = path,
         name = packages.create_name(path),
+        exact_version = None,
         from_version = from_version,
         revision = None,
         products = products,
@@ -53,6 +68,7 @@ def _create_test(ctx):
         url = url,
         path = None,
         name = name,
+        exact_version = None,
         from_version = from_version,
         revision = None,
         products = products,
@@ -71,6 +87,7 @@ def _create_test(ctx):
         url = url,
         path = None,
         name = name,
+        exact_version = None,
         from_version = None,
         revision = revision,
         products = products,


### PR DESCRIPTION
Closes #98.

- Updated `spm_pkg` to accept `exact_version` for a package.
- Upgraded `bazel-starlib` to version `0.2.1`.