### PR TITLE
Upgraded to rules_bazel_integration_test 0.5.0.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,12 @@ jobs:
   macos_build:
     runs-on: macos-11.0
     steps:
+    - name: DEBUG
+      shell: bash
+      run: |
+        xcodebuild -version
+        exit 1
+        
     - uses: actions/checkout@v2
     - uses: cgrindel/gha_set_up_bazel@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ jobs:
 
   macos_build:
     runs-on: macos-11.0
+    # DEBUG BEGIN
+    env:
+      USE_BAZEL_VERSION: cgrindel/6.0.0-keith_patch
+    # DEBUG END
     steps:
     - uses: actions/checkout@v2
     - uses: cgrindel/gha_set_up_bazel@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,10 @@ jobs:
 
   macos_build:
     runs-on: macos-11.0
-    # DEBUG BEGIN
+    # GH112: Remove the use of a custom Bazel when Keith's patch is merged and 
+    # released.
     env:
       USE_BAZEL_VERSION: cgrindel/6.0.0-keith_patch
-    # DEBUG END
     steps:
     - uses: actions/checkout@v2
     - uses: cgrindel/gha_set_up_bazel@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,6 @@ jobs:
   macos_build:
     runs-on: macos-11.0
     steps:
-    - name: DEBUG
-      shell: bash
-      run: |
-        xcodebuild -version
-        exit 1
-        
     - uses: actions/checkout@v2
     - uses: cgrindel/gha_set_up_bazel@v1
       with:

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -5,7 +5,7 @@ load(
 )
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(
-    "@cgrindel_rules_bazel_integration_test//bazel_integration_test:bazel_integration_test.bzl",
+    "@cgrindel_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
     "integration_test_utils",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -55,6 +55,6 @@ load("@cgrindel_rules_bazel_integration_test//bazel_integration_test:deps.bzl", 
 bazel_integration_test_rules_dependencies()
 
 load("//:bazel_versions.bzl", "SUPPORTED_BAZEL_VERSIONS")
-load("@build_bazel_integration_testing//tools:repositories.bzl", "bazel_binaries")
+load("@cgrindel_rules_bazel_integration_test//bazel_integration_test:defs.bzl", "bazel_binaries")
 
 bazel_binaries(versions = SUPPORTED_BAZEL_VERSIONS)

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load(
-    "@cgrindel_rules_bazel_integration_test//bazel_integration_test:bazel_integration_test.bzl",
+    "@cgrindel_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
     "bazel_integration_test",
     "bazel_integration_tests",
     "default_test_runner",
@@ -97,6 +97,7 @@ default_test_runner(
         test_runner = ":default_test_runner",
         workspace_files = integration_test_utils.glob_workspace_files(example) +
                           ADDITIONAL_WORKSPACE_FILES,
+        workspace_path = example,
     )
     for example in ALL_OS_TEST_EXAMPLES
 ]
@@ -111,6 +112,7 @@ default_test_runner(
         test_runner = ":default_test_runner",
         workspace_files = integration_test_utils.glob_workspace_files(example) +
                           ADDITIONAL_WORKSPACE_FILES,
+        workspace_path = example,
     )
     for example in MACOS_TEST_EXAMPLES
 ]

--- a/examples/incompatible_xcode_use_dev_dir_attr_test.sh
+++ b/examples/incompatible_xcode_use_dev_dir_attr_test.sh
@@ -35,6 +35,8 @@ do_sudo() {
 
 starting_dir="$(pwd)"
 bazel_cmds=()
+bazel="${BIT_BAZEL_BINARY:-}"
+workspace_dir="${BIT_WORKSPACE_DIR:-}"
 
 # Process args
 while (("$#")); do
@@ -58,14 +60,9 @@ while (("$#")); do
 done
 
 
-[[ -n "${bazel_rel_path:-}" ]] || exit_on_error "Must specify the location of the Bazel binary."
-[[ -n "${workspace_path:-}" ]] || exit_on_error "Must specify the location of the workspace file."
+[[ -n "${bazel:-}" ]] || exit_on_error "Must specify the location of the Bazel binary."
+[[ -n "${workspace_dir:-}" ]] || exit_on_error "Must specify the location of the workspace directory."
 
-starting_path="$(pwd)"
-starting_path="${starting_path%%*( )}"
-bazel="$(normalize_path "${bazel_rel_path}")"
-
-workspace_dir="$(dirname "${workspace_path}")"
 cd "${workspace_dir}"
 
 # BEGIN Custom test logic 

--- a/examples/incompatible_xcode_use_dev_dir_env_test.sh
+++ b/examples/incompatible_xcode_use_dev_dir_env_test.sh
@@ -35,6 +35,8 @@ do_sudo() {
 
 starting_dir="$(pwd)"
 bazel_cmds=()
+bazel="${BIT_BAZEL_BINARY:-}"
+workspace_dir="${BIT_WORKSPACE_DIR:-}"
 
 # Process args
 while (("$#")); do
@@ -58,14 +60,9 @@ while (("$#")); do
 done
 
 
-[[ -n "${bazel_rel_path:-}" ]] || exit_on_error "Must specify the location of the Bazel binary."
-[[ -n "${workspace_path:-}" ]] || exit_on_error "Must specify the location of the workspace file."
+[[ -n "${bazel:-}" ]] || exit_on_error "Must specify the location of the Bazel binary."
+[[ -n "${workspace_dir:-}" ]] || exit_on_error "Must specify the location of the workspace directory."
 
-starting_path="$(pwd)"
-starting_path="${starting_path%%*( )}"
-bazel="$(normalize_path "${bazel_rel_path}")"
-
-workspace_dir="$(dirname "${workspace_path}")"
 cd "${workspace_dir}"
 
 # BEGIN Custom test logic 

--- a/spm/deps.bzl
+++ b/spm/deps.bzl
@@ -39,7 +39,9 @@ def spm_rules_dependencies():
     maybe(
         http_archive,
         name = "cgrindel_rules_bazel_integration_test",
-        sha256 = "50b808269ee09373c099256103c40629db8a66fd884030d7a36cf9a2e8675b75",
-        strip_prefix = "rules_bazel_integration_test-0.3.1",
-        urls = ["https://github.com/cgrindel/rules_bazel_integration_test/archive/v0.3.1.tar.gz"],
+        sha256 = "39071d2ec8e3be74c8c4a6c395247182b987cdb78d3a3955b39e343ece624982",
+        strip_prefix = "rules_bazel_integration_test-0.5.0",
+        urls = [
+            "http://github.com/cgrindel/rules_bazel_integration_test/archive/v0.5.0.tar.gz",
+        ],
     )


### PR DESCRIPTION
- Use a custom Bazel build for `macos_build` to fix issues with `osx_archs.bzl`. See #112 for more details.