### PR TITLE
Add workarounds to address missing `libswift_Concurrency.dylib`

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -19,7 +19,7 @@ ALL_OS_TEST_EXAMPLES = [
     # GH090: Disabled tests due to error:
     # "Library not loaded: /usr/lib/swift/libswift_Concurrency.dylib"
     #
-    # "local_package",
+    "local_package",
     # "vapor",
 ]
 

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -20,7 +20,7 @@ ALL_OS_TEST_EXAMPLES = [
     # "Library not loaded: /usr/lib/swift/libswift_Concurrency.dylib"
     #
     "local_package",
-    # "vapor",
+    "vapor",
 ]
 
 MACOS_TEST_EXAMPLES = [

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -16,9 +16,6 @@ ALL_OS_TEST_EXAMPLES = [
     "simple",
     "simple_revision",
     "simple_with_binary",
-    # GH090: Disabled tests due to error:
-    # "Library not loaded: /usr/lib/swift/libswift_Concurrency.dylib"
-    #
     "local_package",
     "vapor",
 ]

--- a/examples/local_package/BUILD.bazel
+++ b/examples/local_package/BUILD.bazel
@@ -1,17 +1,36 @@
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary")
 
+config_setting(
+    name = "macos_os",
+    constraint_values = [
+        "@platforms//os:osx",
+    ],
+)
+
+# TODO: FIX ME
+
 swift_binary(
     name = "local_package",
     srcs = ["main.swift"],
     # Workaround for missing libswift_Concurrency.dylib
     # https://forums.swift.org/t/swift-concurrency-back-deploy-issue/53917/10
-    linkopts = [
-        "-Wl",
-        "-weak-lswift_Concurrency",
-        "-Wl",
-        "-rpath",
-        "/usr/lib/swift",
-    ],
+    # linkopts = [
+    #     "-Wl",
+    #     "-weak-lswift_Concurrency",
+    #     "-Wl",
+    #     "-rpath",
+    #     "/usr/lib/swift",
+    # ],
+    linkopts = select({
+        ":macos_os": [
+            "-Wl",
+            "-weak-lswift_Concurrency",
+            "-Wl",
+            "-rpath",
+            "/usr/lib/swift",
+        ],
+        "//conditions:default": [],
+    }),
     visibility = ["//swift:__subpackages__"],
     deps = [
         "@swift_pkgs//foo-kit:FooKit",

--- a/examples/local_package/BUILD.bazel
+++ b/examples/local_package/BUILD.bazel
@@ -7,20 +7,11 @@ config_setting(
     ],
 )
 
-# TODO: FIX ME
-
 swift_binary(
     name = "local_package",
     srcs = ["main.swift"],
     # Workaround for missing libswift_Concurrency.dylib
     # https://forums.swift.org/t/swift-concurrency-back-deploy-issue/53917/10
-    # linkopts = [
-    #     "-Wl",
-    #     "-weak-lswift_Concurrency",
-    #     "-Wl",
-    #     "-rpath",
-    #     "/usr/lib/swift",
-    # ],
     linkopts = select({
         ":macos_os": [
             "-Wl",

--- a/examples/local_package/BUILD.bazel
+++ b/examples/local_package/BUILD.bazel
@@ -1,7 +1,4 @@
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary")
-# load("@build_bazel_rules_apple//apple:macos.bzl", "macos_command_line_application")
-# load("@build_bazel_rules_apple//apple:versioning.bzl", "apple_bundle_version")
-# load("@build_bazel_rules_swift//swift:swift.bzl",  "swift_library")
 
 swift_binary(
     name = "local_package",
@@ -22,32 +19,6 @@ swift_binary(
         "@swift_pkgs//swift-nio:NIO",
     ],
 )
-
-# swift_library(
-#     name = "sources",
-#     srcs = ["main.swift"],
-#     visibility = ["//swift:__subpackages__"],
-#     deps = [
-#         "@swift_pkgs//foo-kit:FooKit",
-#         "@swift_pkgs//swift-log:Logging",
-#         "@swift_pkgs//swift-nio:NIO",
-#     ],
-# )
-
-# apple_bundle_version(
-#     name = "version",
-#     build_version = "1.0",
-# )
-
-# macos_command_line_application(
-#     name = "local_package",
-#     bundle_id = "com.example.local_package",
-#     infoplists = [":Info.plist"],
-#     minimum_os_version = "12",
-#     version = ":version",
-#     visibility = ["//swift:__subpackages__"],
-#     deps = [":sources"],
-# )
 
 sh_test(
     name = "local_package_test",

--- a/examples/local_package/BUILD.bazel
+++ b/examples/local_package/BUILD.bazel
@@ -1,8 +1,20 @@
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary")
+# load("@build_bazel_rules_apple//apple:macos.bzl", "macos_command_line_application")
+# load("@build_bazel_rules_apple//apple:versioning.bzl", "apple_bundle_version")
+# load("@build_bazel_rules_swift//swift:swift.bzl",  "swift_library")
 
 swift_binary(
     name = "local_package",
     srcs = ["main.swift"],
+    # Workaround for missing libswift_Concurrency.dylib
+    # https://forums.swift.org/t/swift-concurrency-back-deploy-issue/53917/10
+    linkopts = [
+        "-Wl",
+        "-weak-lswift_Concurrency",
+        "-Wl",
+        "-rpath",
+        "/usr/lib/swift",
+    ],
     visibility = ["//swift:__subpackages__"],
     deps = [
         "@swift_pkgs//foo-kit:FooKit",
@@ -10,6 +22,32 @@ swift_binary(
         "@swift_pkgs//swift-nio:NIO",
     ],
 )
+
+# swift_library(
+#     name = "sources",
+#     srcs = ["main.swift"],
+#     visibility = ["//swift:__subpackages__"],
+#     deps = [
+#         "@swift_pkgs//foo-kit:FooKit",
+#         "@swift_pkgs//swift-log:Logging",
+#         "@swift_pkgs//swift-nio:NIO",
+#     ],
+# )
+
+# apple_bundle_version(
+#     name = "version",
+#     build_version = "1.0",
+# )
+
+# macos_command_line_application(
+#     name = "local_package",
+#     bundle_id = "com.example.local_package",
+#     infoplists = [":Info.plist"],
+#     minimum_os_version = "12",
+#     version = ":version",
+#     visibility = ["//swift:__subpackages__"],
+#     deps = [":sources"],
+# )
 
 sh_test(
     name = "local_package_test",

--- a/examples/local_package/WORKSPACE
+++ b/examples/local_package/WORKSPACE
@@ -63,4 +63,9 @@ spm_repositories(
             products = ["FooKit"],
         ),
     ],
+    # New concurrency stuff is supported in macOS v12.
+    platforms = [
+        ".macOS(.v12)",
+    ],
+    swift_version = "5.5",
 )

--- a/examples/local_package/WORKSPACE
+++ b/examples/local_package/WORKSPACE
@@ -48,12 +48,12 @@ spm_repositories(
     name = "swift_pkgs",
     dependencies = [
         spm_pkg(
-            from_version = "1.0.0",
+            exact_version = "1.4.2",
             products = ["Logging"],
             url = "https://github.com/apple/swift-log.git",
         ),
         spm_pkg(
-            from_version = "2.0.0",
+            exact_version = "2.37.0",
             products = ["NIO"],
             url = "https://github.com/apple/swift-nio.git",
         ),

--- a/examples/vapor/Tests/AppTests/BUILD.bazel
+++ b/examples/vapor/Tests/AppTests/BUILD.bazel
@@ -3,9 +3,18 @@ load("@build_bazel_rules_swift//swift:swift.bzl", "swift_test")
 swift_test(
     name = "AppTests",
     srcs = glob(["*.swift"]),
+    # Workaround for missing libswift_Concurrency.dylib
+    # https://forums.swift.org/t/swift-concurrency-back-deploy-issue/53917/10
+    linkopts = [
+        "-Wl",
+        "-weak-lswift_Concurrency",
+        "-Wl",
+        "-rpath",
+        "/usr/lib/swift",
+    ],
     deps = [
         "//Sources/App/Configuration",
         "@swift_pkgs//vapor:XCTVapor",
-        "@zlib//:zlib",
+        "@zlib",
     ],
 )

--- a/examples/vapor/Tests/AppTests/BUILD.bazel
+++ b/examples/vapor/Tests/AppTests/BUILD.bazel
@@ -1,17 +1,27 @@
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_test")
 
+config_setting(
+    name = "macos_os",
+    constraint_values = [
+        "@platforms//os:osx",
+    ],
+)
+
 swift_test(
     name = "AppTests",
     srcs = glob(["*.swift"]),
     # Workaround for missing libswift_Concurrency.dylib
     # https://forums.swift.org/t/swift-concurrency-back-deploy-issue/53917/10
-    linkopts = [
-        "-Wl",
-        "-weak-lswift_Concurrency",
-        "-Wl",
-        "-rpath",
-        "/usr/lib/swift",
-    ],
+    linkopts = select({
+        ":macos_os": [
+            "-Wl",
+            "-weak-lswift_Concurrency",
+            "-Wl",
+            "-rpath",
+            "/usr/lib/swift",
+        ],
+        "//conditions:default": [],
+    }),
     deps = [
         "//Sources/App/Configuration",
         "@swift_pkgs//vapor:XCTVapor",

--- a/examples/vapor/WORKSPACE
+++ b/examples/vapor/WORKSPACE
@@ -47,7 +47,7 @@ spm_repositories(
     dependencies = [
         spm_pkg(
             "https://github.com/vapor/vapor.git",
-            from_version = "4.0.0",
+            exact_version = "4.54.1",
             products = [
                 "Vapor",
                 "XCTVapor",
@@ -55,16 +55,18 @@ spm_repositories(
         ),
         spm_pkg(
             "https://github.com/vapor/fluent.git",
-            from_version = "4.0.0",
+            exact_version = "4.4.0",
             products = ["Fluent"],
         ),
         spm_pkg(
             "https://github.com/vapor/fluent-sqlite-driver.git",
-            from_version = "4.0.0",
+            exact_version = "4.1.0",
             products = ["FluentSQLiteDriver"],
         ),
     ],
+    # New concurrency stuff is supported in macOS v12.
     platforms = [
-        ".macOS(.v10_15)",
+        ".macOS(.v12)",
     ],
+    swift_version = "5.5",
 )


### PR DESCRIPTION
Closes #90.

- Added platform declarations and linker flags to work around the missing `libswift_Concurrency.dylib` errors.