### PR TITLE
Added support for nested clang public header files and added example using libwebp-Xcode

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,8 +3,8 @@
 # This lets us glob() up all the files inside the examples to make them inputs to tests
 # (Note, we cannot use `common --deleted_packages` because the bazel version command doesn't support it)
 # To update these lines, run `bazel run @cgrindel_rules_bazel_integration_test//tools:update_deleted_packages`.
-build --deleted_packages=examples/ios_sim/Sources/Foo,examples/ios_sim/Tests/FooTests,examples/local_package,examples/simple,examples/simple_revision,examples/simple_with_binary,examples/simple_with_dev_dir,examples/vapor/Sources/App/Configuration,examples/vapor/Sources/App/Migrations,examples/vapor/Sources/App/Models,examples/vapor/Sources/Run,examples/vapor/Tests/AppTests
-query --deleted_packages=examples/ios_sim/Sources/Foo,examples/ios_sim/Tests/FooTests,examples/local_package,examples/simple,examples/simple_revision,examples/simple_with_binary,examples/simple_with_dev_dir,examples/vapor/Sources/App/Configuration,examples/vapor/Sources/App/Migrations,examples/vapor/Sources/App/Models,examples/vapor/Sources/Run,examples/vapor/Tests/AppTests
+build --deleted_packages=examples/interesting_deps,examples/ios_sim/Sources/Foo,examples/ios_sim/Tests/FooTests,examples/local_package,examples/simple,examples/simple_revision,examples/simple_with_binary,examples/simple_with_dev_dir,examples/vapor/Sources/App/Configuration,examples/vapor/Sources/App/Migrations,examples/vapor/Sources/App/Models,examples/vapor/Sources/Run,examples/vapor/Tests/AppTests
+query --deleted_packages=examples/interesting_deps,examples/ios_sim/Sources/Foo,examples/ios_sim/Tests/FooTests,examples/local_package,examples/simple,examples/simple_revision,examples/simple_with_binary,examples/simple_with_dev_dir,examples/vapor/Sources/App/Configuration,examples/vapor/Sources/App/Migrations,examples/vapor/Sources/App/Models,examples/vapor/Sources/Run,examples/vapor/Tests/AppTests
 
 # Import Shared settings
 import %workspace%/shared.bazelrc

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -18,6 +18,7 @@ bzlformat_missing_pkgs(
 updatesrc_update_all(
     name = "update_all",
     targets_to_run = [
+        "@cgrindel_rules_bazel_integration_test//tools:update_deleted_packages",
         ":bzlformat_missing_pkgs_fix",
     ],
 )

--- a/doc/spm_common.md
+++ b/doc/spm_common.md
@@ -48,3 +48,25 @@ A two item `tuple` where the first item is the package name and
   the second item is the target name.
 
 
+<a id="#spm_common.is_include_hdr_path"></a>
+
+## spm_common.is_include_hdr_path
+
+<pre>
+spm_common.is_include_hdr_path(<a href="#spm_common.is_include_hdr_path-path">path</a>)
+</pre>
+
+Determines whether the path is a public header.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="spm_common.is_include_hdr_path-path"></a>path |  A path <code>string</code> value.   |  none |
+
+**RETURNS**
+
+A `bool` indicating whether the path is a public header.
+
+

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -18,6 +18,7 @@ ALL_OS_TEST_EXAMPLES = [
     "simple_with_binary",
     "local_package",
     "vapor",
+    "interesting_deps",
 ]
 
 MACOS_TEST_EXAMPLES = [

--- a/examples/README.md
+++ b/examples/README.md
@@ -28,6 +28,8 @@
 - [Vapor](/examples/vapor): Demonstrates a dependency on [Vapor](https://github.com/vapor/vapor), a
   popular web framework for Swift. This examples also demonstrates that `rules_spm` can handle custom
   module maps in dependent Swift packages.
+- [Interesting Dependencies](/examples/interesting_deps): Demonstrates the declaration of dependent
+  Swift packages with unique or non-standard characteristics.
 
 ## Integration Tests
 

--- a/examples/interesting_deps/BUILD.bazel
+++ b/examples/interesting_deps/BUILD.bazel
@@ -1,0 +1,44 @@
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary")
+
+swift_binary(
+    name = "simple",
+    srcs = ["main.swift"],
+    visibility = ["//swift:__subpackages__"],
+    deps = [
+        "@swift_pkgs//swift-log:Logging",
+    ],
+)
+
+sh_test(
+    name = "simple_test",
+    srcs = ["simple_test.sh"],
+    data = [":simple"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)
+
+# Used to test building with a different version of Xcode. In this case, this
+# is not the latest version of Xcode. Run the following to test with this
+# version:
+#
+#    bazel test --xcode_version_config=//:host_xcodes //...
+#
+# For more information on how this all works, see
+# https://www.smileykeith.com/2021/03/08/locking-xcode-in-bazel/
+
+xcode_version(
+    name = "version12_4_0_12D4e",
+    aliases = ["12D4e"],
+    default_ios_sdk_version = "14.4",
+    default_macos_sdk_version = "11.1",
+    default_tvos_sdk_version = "14.3",
+    default_watchos_sdk_version = "7.2",
+    version = "12.4.0.12D4e",
+)
+
+xcode_config(
+    name = "host_xcodes",
+    default = ":version12_4_0_12D4e",
+    versions = [
+        ":version12_4_0_12D4e",
+    ],
+)

--- a/examples/interesting_deps/README.md
+++ b/examples/interesting_deps/README.md
@@ -1,0 +1,36 @@
+# Example with Interesting Dependencies
+
+This example demonstrates how to declare dependent Swift packages with unique or non-standard
+characteristics.
+
+
+## libwebp-Xcode
+
+The [libwebp-Xcode](https://github.com/SDWebImage/libwebp-Xcode) package is interesting for the
+following reasons.
+
+
+### Package Name Does Not Match the Repository Name
+
+The name of the package in the `Package.swift` (`libwebp`) does not match the name of the Git
+repository (`libwebp-Xcode`). Since `rules_spm` is unable to derive the package name from the URL,
+we must specify the correct package name in the `spm_pkg` declaration.
+
+```python
+        spm_pkg(
+            # Need to specify for the package because the URL basename does not
+            # match the package name in the Package.swift.
+            name = "libwebp",
+            from_version = "1.2.1",
+            products = ["libwebp"],
+            url = "https://github.com/SDWebImage/libwebp-Xcode.git",
+        ),
+```
+
+
+### Clang Headers in Nested Include Directory
+
+The package contains a clang target. The public header files for the target are located in a
+directory that is nested under the `include` directory. The header discovery logic for `rules_spm`
+will include all of the header files that reside directly in the `include` directory or in any of
+its subdirectories.

--- a/examples/interesting_deps/WORKSPACE
+++ b/examples/interesting_deps/WORKSPACE
@@ -1,0 +1,58 @@
+workspace(name = "simple_example")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+local_repository(
+    name = "cgrindel_rules_spm",
+    path = "../..",
+)
+
+load(
+    "@cgrindel_rules_spm//spm:deps.bzl",
+    "spm_rules_dependencies",
+)
+
+spm_rules_dependencies()
+
+load("@cgrindel_bazel_starlib//:deps.bzl", "bazel_starlib_dependencies")
+
+bazel_starlib_dependencies()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
+load(
+    "@build_bazel_rules_swift//swift:repositories.bzl",
+    "swift_rules_dependencies",
+)
+
+swift_rules_dependencies()
+
+load(
+    "@build_bazel_rules_swift//swift:extras.bzl",
+    "swift_rules_extra_dependencies",
+)
+
+swift_rules_extra_dependencies()
+
+load("@cgrindel_rules_spm//spm:defs.bzl", "spm_pkg", "spm_repositories")
+
+spm_repositories(
+    name = "swift_pkgs",
+    dependencies = [
+        spm_pkg(
+            "https://github.com/apple/swift-log.git",
+            exact_version = "1.4.2",
+            products = ["Logging"],
+        ),
+        spm_pkg(
+            # Need to specify for the package because the URL basename does not
+            # match the package name in the Package.swift.
+            name = "libwebp",
+            exact_version = "1.2.1",
+            products = ["libwebp"],
+            url = "https://github.com/SDWebImage/libwebp-Xcode.git",
+        ),
+    ],
+)

--- a/examples/interesting_deps/main.swift
+++ b/examples/interesting_deps/main.swift
@@ -1,0 +1,4 @@
+import Logging
+
+let logger = Logger(label: "com.example.main")
+logger.info("Hello World!")

--- a/examples/interesting_deps/simple_test.sh
+++ b/examples/interesting_deps/simple_test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+err_msg() {
+  local msg="$1"
+  echo >&2 "${msg}"
+  exit 1
+}
+
+workspace="simple_example"
+binary="$(rlocation "${workspace}/simple")"
+
+expected="Hello World"
+"${binary}" | grep "${expected}" || err_msg "Failed to find expected output. ${expected}"

--- a/examples/simple/WORKSPACE
+++ b/examples/simple/WORKSPACE
@@ -46,5 +46,13 @@ spm_repositories(
             exact_version = "1.4.2",
             products = ["Logging"],
         ),
+        spm_pkg(
+            # Need to specify for the package because the URL basename does not
+            # match the package name in the Package.swift.
+            name = "libwebp",
+            from_version = "1.2.1",
+            products = ["libwebp"],
+            url = "https://github.com/SDWebImage/libwebp-Xcode.git",
+        ),
     ],
 )

--- a/examples/simple/WORKSPACE
+++ b/examples/simple/WORKSPACE
@@ -46,13 +46,5 @@ spm_repositories(
             exact_version = "1.4.2",
             products = ["Logging"],
         ),
-        spm_pkg(
-            # Need to specify for the package because the URL basename does not
-            # match the package name in the Package.swift.
-            name = "libwebp",
-            from_version = "1.2.1",
-            products = ["libwebp"],
-            url = "https://github.com/SDWebImage/libwebp-Xcode.git",
-        ),
     ],
 )

--- a/spm/private/spm_common.bzl
+++ b/spm/private/spm_common.bzl
@@ -27,12 +27,26 @@ def _split_clang_hdrs_key(key):
         fail("Unexpected clang headers key value. %s" % (key))
     return (parts[0], parts[1])
 
+def _is_include_hdr_path(path):
+    """Determines whether the path is a public header.
+
+    Args:
+        path: A path `string` value.
+
+    Returns:
+        A `bool` indicating whether the path is a public header.
+    """
+    root, ext = paths.split_extension(path)
+    contains_include_dir = path.find("/include/") > -1
+    return contains_include_dir and ext == ".h"
+
 _build_dirname = "spm_build"
 _checkouts_path = paths.join(_build_dirname, "checkouts")
 
 spm_common = struct(
     create_clang_hdrs_key = _create_clang_hdrs_key,
     split_clang_hdrs_key = _split_clang_hdrs_key,
+    is_include_hdr_path = _is_include_hdr_path,
     build_dirname = _build_dirname,
     checkouts_path = _checkouts_path,
 )

--- a/spm/private/spm_repositories.bzl
+++ b/spm/private/spm_repositories.bzl
@@ -636,7 +636,8 @@ Resolution of SPM packages for {repo_name} failed. args: {exec_args}\n{stderr}\
             clang_hdr_paths = _get_clang_hdrs_for_target(
                 repository_ctx,
                 clang_target,
-                pkg_root_path = paths.join(spm_common.checkouts_path, dep_name),
+                # pkg_root_path = paths.join(spm_common.checkouts_path, dep_name),
+                pkg_root_path = dep_pkg_desc["path"],
             )
             clang_hdrs_key = spm_common.create_clang_hdrs_key(
                 dep_name,
@@ -648,11 +649,25 @@ Resolution of SPM packages for {repo_name} failed. args: {exec_args}\n{stderr}\
     # dependencies
     declared_product_refs = packages.get_product_refs(pkgs)
 
+    # DEBUG BEGIN
+    print("*** CHUCK pkg_descs_dict: ")
+    for key in pkg_descs_dict:
+        print("*** CHUCK", key, ":", pkg_descs_dict[key])
+
+    # DEBUG END
+
     # Index the executable products by package name.
     exec_products_dict = {}
     for product_ref in declared_product_refs:
         ref_type, pkg_name, product_name = refs.split(product_ref)
         exec_products = exec_products_dict.setdefault(pkg_name, default = [])
+
+        # DEBUG BEGIN
+        print("*** CHUCK product_ref: ", product_ref)
+        print("*** CHUCK product_name: ", product_name)
+        print("*** CHUCK pkg_name: ", pkg_name)
+
+        # DEBUG END
         product = pds.get_product(pkg_descs_dict[pkg_name], product_name)
         if pds.is_executable_product(product):
             exec_products.append(product)

--- a/spm/private/spm_repositories.bzl
+++ b/spm/private/spm_repositories.bzl
@@ -386,15 +386,6 @@ def _get_clang_hdrs_for_target(repository_ctx, target, pkg_root_path = ""):
     src_path = paths.join(pkg_root_path, target["path"])
     module_paths = _list_files_under(repository_ctx, src_path)
 
-    # DEBUG BEGIN
-    print("*** CHUCK target: ", target)
-    print("*** CHUCK src_path: ", src_path)
-    print("*** CHUCK module_paths: ")
-    for idx, item in enumerate(module_paths):
-        print("*** CHUCK", idx, ":", item)
-
-    # DEBUG END
-
     modulemap_paths = [p for p in module_paths if _is_modulemap_path(p)]
     modulemap_paths_len = len(modulemap_paths)
     if modulemap_paths_len > 1:

--- a/spm/private/spm_repositories.bzl
+++ b/spm/private/spm_repositories.bzl
@@ -623,7 +623,6 @@ Resolution of SPM packages for {repo_name} failed. args: {exec_args}\n{stderr}\
             clang_hdr_paths = _get_clang_hdrs_for_target(
                 repository_ctx,
                 clang_target,
-                # pkg_root_path = paths.join(spm_common.checkouts_path, dep_name),
                 pkg_root_path = dep_pkg_desc["path"],
             )
             clang_hdrs_key = spm_common.create_clang_hdrs_key(

--- a/test/spm_common_tests.bzl
+++ b/test/spm_common_tests.bzl
@@ -22,9 +22,26 @@ def _split_clang_hdrs_key_test(ctx):
 
 split_clang_hdrs_key_test = unittest.make(_split_clang_hdrs_key_test)
 
+def _is_include_hdr_path_test(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.true(env, spm_common.is_include_hdr_path("foo/bar/include/chicken.h"))
+    asserts.false(env, spm_common.is_include_hdr_path("foo/bar/chicken.h"))
+
+    # Find headers that are not directly under the include directory.
+    # Example: https://github.com/SDWebImage/libwebp-Xcode/tree/master/include/webp
+    asserts.true(env, spm_common.is_include_hdr_path("foo/bar/include/chicken/smidgen.h"))
+    asserts.false(env, spm_common.is_include_hdr_path("foo/bar/not_include/chicken/smidgen.h"))
+    asserts.false(env, spm_common.is_include_hdr_path("foo/bar/include_not/chicken/smidgen.h"))
+
+    return unittest.end(env)
+
+is_include_hdr_path_test = unittest.make(_is_include_hdr_path_test)
+
 def spm_common_test_suite():
     return unittest.suite(
         "spm_common_tests",
         create_clang_hdrs_key_test,
         split_clang_hdrs_key_test,
+        is_include_hdr_path_test,
     )


### PR DESCRIPTION
Closes #118.
Includes @pomozoff fix in #117.

- Moved `is_include_hdr_path` to `spm_common`.
- Updated clang public header discovery logic to look in subdirectories of `include` directory.
- Added example demonstrating interesting Swift package dependencies.