### PR TITLE
Add 'public' as a dir that may contain public headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 # Ignore Bazel symlinks
 bazel-*
 
+# macOS
+.DS_Store
+
+# VSCode
+.vscode

--- a/spm/private/spm_common.bzl
+++ b/spm/private/spm_common.bzl
@@ -37,7 +37,7 @@ def _is_include_hdr_path(path):
         A `bool` indicating whether the path is a public header.
     """
     root, ext = paths.split_extension(path)
-    contains_include_dir = path.find("/include/") > -1
+    contains_include_dir = (path.find("/include/") > -1) or (path.find("/public/") > -1)
     return contains_include_dir and ext == ".h"
 
 _build_dirname = "spm_build"


### PR DESCRIPTION
The [TrustKit]() package holds its public headers in the _public_ dir.
Actually, it should be configured from the outside.