### PR TITLE
Add an example with TrustKit package

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,8 +3,8 @@
 # This lets us glob() up all the files inside the examples to make them inputs to tests
 # (Note, we cannot use `common --deleted_packages` because the bazel version command doesn't support it)
 # To update these lines, run `bazel run @cgrindel_rules_bazel_integration_test//tools:update_deleted_packages`.
-build --deleted_packages=examples/interesting_deps,examples/ios_sim/Sources/Foo,examples/ios_sim/Tests/FooTests,examples/local_package,examples/simple,examples/simple_revision,examples/simple_with_binary,examples/simple_with_dev_dir,examples/vapor/Sources/App/Configuration,examples/vapor/Sources/App/Migrations,examples/vapor/Sources/App/Models,examples/vapor/Sources/Run,examples/vapor/Tests/AppTests
-query --deleted_packages=examples/interesting_deps,examples/ios_sim/Sources/Foo,examples/ios_sim/Tests/FooTests,examples/local_package,examples/simple,examples/simple_revision,examples/simple_with_binary,examples/simple_with_dev_dir,examples/vapor/Sources/App/Configuration,examples/vapor/Sources/App/Migrations,examples/vapor/Sources/App/Models,examples/vapor/Sources/Run,examples/vapor/Tests/AppTests
+build --deleted_packages=examples/interesting_deps,examples/ios_sim/Sources/Foo,examples/ios_sim/Tests/FooTests,examples/local_package,examples/public_hdrs,examples/simple,examples/simple_revision,examples/simple_with_binary,examples/simple_with_dev_dir,examples/vapor/Sources/App/Configuration,examples/vapor/Sources/App/Migrations,examples/vapor/Sources/App/Models,examples/vapor/Sources/Run,examples/vapor/Tests/AppTests
+query --deleted_packages=examples/interesting_deps,examples/ios_sim/Sources/Foo,examples/ios_sim/Tests/FooTests,examples/local_package,examples/public_hdrs,examples/simple,examples/simple_revision,examples/simple_with_binary,examples/simple_with_dev_dir,examples/vapor/Sources/App/Configuration,examples/vapor/Sources/App/Migrations,examples/vapor/Sources/App/Models,examples/vapor/Sources/Run,examples/vapor/Tests/AppTests
 
 # Import Shared settings
 import %workspace%/shared.bazelrc

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 # Ignore Bazel symlinks
 bazel-*
 
+# macOS
+.DS_Store
+
+# VSCode
+.vscode

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -19,6 +19,7 @@ ALL_OS_TEST_EXAMPLES = [
     "local_package",
     "vapor",
     "interesting_deps",
+    "public_hdrs",
 ]
 
 MACOS_TEST_EXAMPLES = [

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -19,11 +19,11 @@ ALL_OS_TEST_EXAMPLES = [
     "local_package",
     "vapor",
     "interesting_deps",
-    "public_hdrs",
 ]
 
 MACOS_TEST_EXAMPLES = [
     "ios_sim",
+    "public_hdrs",
 ]
 
 NO_SUDO_INTEGRATION_TESTS = [

--- a/examples/README.md
+++ b/examples/README.md
@@ -30,6 +30,8 @@
   module maps in dependent Swift packages.
 - [Interesting Dependencies](/examples/interesting_deps): Demonstrates the declaration of dependent
   Swift packages with unique or non-standard characteristics.
+- [Public Headers](/examples/public_hdrs): Example of the package that holds its public headers in a
+  'public' directory.
 
 ## Integration Tests
 

--- a/examples/public_hdrs/BUILD.bazel
+++ b/examples/public_hdrs/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary")
+
+swift_binary(
+    name = "trustkit",
+    srcs = ["main.swift"],
+    visibility = ["//swift:__subpackages__"],
+    deps = [
+        "@swift_pkgs//TrustKit:TrustKit",
+    ],
+)
+
+sh_test(
+    name = "trustkit_test",
+    srcs = ["trustkit_test.sh"],
+    data = [":trustkit"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)

--- a/examples/public_hdrs/README.md
+++ b/examples/public_hdrs/README.md
@@ -1,0 +1,3 @@
+# Example of a package with Public Headers in a local subdirectory
+
+This example builds the [TrustKit](https://github.com/datatheorem/TrustKit) package that holds its public headers in the 'public' subdirectory.

--- a/examples/public_hdrs/WORKSPACE
+++ b/examples/public_hdrs/WORKSPACE
@@ -1,0 +1,60 @@
+workspace(name = "trustkit_with_dev_dir_example")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+local_repository(
+    name = "cgrindel_rules_spm",
+    path = "../..",
+)
+
+load(
+    "@cgrindel_rules_spm//spm:deps.bzl",
+    "spm_rules_dependencies",
+)
+
+spm_rules_dependencies()
+
+load("@cgrindel_bazel_starlib//:deps.bzl", "bazel_starlib_dependencies")
+
+bazel_starlib_dependencies()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
+load(
+    "@build_bazel_rules_swift//swift:repositories.bzl",
+    "swift_rules_dependencies",
+)
+
+swift_rules_dependencies()
+
+load(
+    "@build_bazel_rules_swift//swift:extras.bzl",
+    "swift_rules_extra_dependencies",
+)
+
+swift_rules_extra_dependencies()
+
+load("@cgrindel_rules_spm//spm:defs.bzl", "spm_pkg", "spm_repositories")
+
+spm_repositories(
+    name = "swift_pkgs",
+    dependencies = [
+        spm_pkg(
+            url = "https://github.com/datatheorem/TrustKit.git",
+            from_version = "2.0.0",
+            products = ["TrustKitStatic"],
+        ),
+    ],
+    platforms = [
+        ".iOS(.v13)",
+        ".macOS(.v10_14)",
+    ],
+    env = {
+        # If you are testing this locally, set this value to a valid Xcode
+        # path. This value is valid for the Github action runner host for
+        # macos-11.
+        # "DEVELOPER_DIR": "/Applications/Xcode_12.5.1.app",
+    },
+)

--- a/examples/public_hdrs/main.swift
+++ b/examples/public_hdrs/main.swift
@@ -1,0 +1,23 @@
+import TrustKit
+
+let trustKitConfig =
+[
+    kTSKSwizzleNetworkDelegates: false,
+    kTSKPinnedDomains:
+    [
+        "yahoo.com": [
+            kTSKExpirationDate: "2022-02-08",
+            kTSKPublicKeyHashes:
+            [
+                "JbQbUG5JMJUoI6brnx0x3vZF6jilxsapbXGVfjhN8Fg=",
+                "WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18="
+            ],
+        ]
+    ]
+] as [String : Any]
+
+TrustKit.setLoggerBlock {
+    print($0)
+}
+
+let _ = TrustKit(configuration: trustKitConfig)

--- a/examples/public_hdrs/main.swift
+++ b/examples/public_hdrs/main.swift
@@ -1,23 +1,23 @@
 import TrustKit
 
 let trustKitConfig =
-[
-    kTSKSwizzleNetworkDelegates: false,
-    kTSKPinnedDomains:
     [
-        "yahoo.com": [
-            kTSKExpirationDate: "2022-02-08",
-            kTSKPublicKeyHashes:
+        kTSKSwizzleNetworkDelegates: false,
+        kTSKPinnedDomains:
             [
-                "JbQbUG5JMJUoI6brnx0x3vZF6jilxsapbXGVfjhN8Fg=",
-                "WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18="
+                "yahoo.com": [
+                    kTSKExpirationDate: "2022-02-08",
+                    kTSKPublicKeyHashes:
+                        [
+                            "JbQbUG5JMJUoI6brnx0x3vZF6jilxsapbXGVfjhN8Fg=",
+                            "WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=",
+                        ],
+                ],
             ],
-        ]
-    ]
-] as [String : Any]
+    ] as [String: Any]
 
 TrustKit.setLoggerBlock {
     print($0)
 }
 
-let _ = TrustKit(configuration: trustKitConfig)
+_ = TrustKit(configuration: trustKitConfig)

--- a/examples/public_hdrs/trustkit_test.sh
+++ b/examples/public_hdrs/trustkit_test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+err_msg() {
+  local msg="$1"
+  echo >&2 "${msg}"
+  exit 1
+}
+
+workspace="trustkit_with_dev_dir_example"
+binary="$(rlocation "${workspace}/trustkit")"
+
+expected="Successfully initialized with configuration"
+"${binary}" | grep "${expected}" || err_msg "Failed to find expected output. ${expected}"

--- a/spm/private/spm_common.bzl
+++ b/spm/private/spm_common.bzl
@@ -37,7 +37,7 @@ def _is_include_hdr_path(path):
         A `bool` indicating whether the path is a public header.
     """
     root, ext = paths.split_extension(path)
-    contains_include_dir = path.find("/include/") > -1
+    contains_include_dir = (path.find("/include/") > -1) or (path.find("/public/") > -1)
     return contains_include_dir and ext == ".h"
 
 _build_dirname = "spm_build"

--- a/spm/private/spm_common.bzl
+++ b/spm/private/spm_common.bzl
@@ -47,9 +47,6 @@ def _is_include_hdr_path(path):
             return True
     return False
 
-    # contains_include_dir = (path.find("/include/") > -1) or (path.find("/public/") > -1)
-    # return contains_include_dir and ext == ".h"
-
 _build_dirname = "spm_build"
 _checkouts_path = paths.join(_build_dirname, "checkouts")
 

--- a/spm/private/spm_common.bzl
+++ b/spm/private/spm_common.bzl
@@ -27,6 +27,9 @@ def _split_clang_hdrs_key(key):
         fail("Unexpected clang headers key value. %s" % (key))
     return (parts[0], parts[1])
 
+# Directory names that may include public header files.
+_PUBLIC_HDR_DIRNAMES = ["include", "public"]
+
 def _is_include_hdr_path(path):
     """Determines whether the path is a public header.
 
@@ -37,8 +40,15 @@ def _is_include_hdr_path(path):
         A `bool` indicating whether the path is a public header.
     """
     root, ext = paths.split_extension(path)
-    contains_include_dir = (path.find("/include/") > -1) or (path.find("/public/") > -1)
-    return contains_include_dir and ext == ".h"
+    if ext != ".h":
+        return False
+    for dirname in _PUBLIC_HDR_DIRNAMES:
+        if (path.find("/%s/" % dirname) > -1) or path.startswith("%s/" % dirname):
+            return True
+    return False
+
+    # contains_include_dir = (path.find("/include/") > -1) or (path.find("/public/") > -1)
+    # return contains_include_dir and ext == ".h"
 
 _build_dirname = "spm_build"
 _checkouts_path = paths.join(_build_dirname, "checkouts")

--- a/test/spm_common_tests.bzl
+++ b/test/spm_common_tests.bzl
@@ -26,6 +26,8 @@ def _is_include_hdr_path_test(ctx):
     env = unittest.begin(ctx)
 
     asserts.true(env, spm_common.is_include_hdr_path("foo/bar/include/chicken.h"))
+    asserts.true(env, spm_common.is_include_hdr_path("foo/public/chicken.h"))
+    asserts.true(env, spm_common.is_include_hdr_path("public/chicken.h"))
     asserts.false(env, spm_common.is_include_hdr_path("foo/bar/chicken.h"))
 
     # Find headers that are not directly under the include directory.


### PR DESCRIPTION
Add `public` as a well-known public header file location.
Add the [TrustKit](https://github.com/datatheorem/TrustKit) package as an example.
Add more tests.

P.S. Based on PR #122