### PR TITLE
Default vapor example integration test to use Xcode 13.1

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,8 +3,8 @@
 # This lets us glob() up all the files inside the examples to make them inputs to tests
 # (Note, we cannot use `common --deleted_packages` because the bazel version command doesn't support it)
 # To update these lines, run `bazel run @cgrindel_rules_bazel_integration_test//tools:update_deleted_packages`.
-build --deleted_packages=examples/interesting_deps,examples/ios_sim/Sources/Foo,examples/ios_sim/Tests/FooTests,examples/local_package,examples/public_hdrs,examples/simple,examples/simple_revision,examples/simple_with_binary,examples/simple_with_dev_dir,examples/vapor/Sources/App/Configuration,examples/vapor/Sources/App/Migrations,examples/vapor/Sources/App/Models,examples/vapor/Sources/Run,examples/vapor/Tests/AppTests
-query --deleted_packages=examples/interesting_deps,examples/ios_sim/Sources/Foo,examples/ios_sim/Tests/FooTests,examples/local_package,examples/public_hdrs,examples/simple,examples/simple_revision,examples/simple_with_binary,examples/simple_with_dev_dir,examples/vapor/Sources/App/Configuration,examples/vapor/Sources/App/Migrations,examples/vapor/Sources/App/Models,examples/vapor/Sources/Run,examples/vapor/Tests/AppTests
+build --deleted_packages=examples/interesting_deps,examples/ios_sim/Sources/Foo,examples/ios_sim/Tests/FooTests,examples/local_package,examples/public_hdrs,examples/simple,examples/simple_revision,examples/simple_with_binary,examples/simple_with_dev_dir,examples/vapor,examples/vapor/Sources/App/Configuration,examples/vapor/Sources/App/Migrations,examples/vapor/Sources/App/Models,examples/vapor/Sources/Run,examples/vapor/Tests/AppTests
+query --deleted_packages=examples/interesting_deps,examples/ios_sim/Sources/Foo,examples/ios_sim/Tests/FooTests,examples/local_package,examples/public_hdrs,examples/simple,examples/simple_revision,examples/simple_with_binary,examples/simple_with_dev_dir,examples/vapor,examples/vapor/Sources/App/Configuration,examples/vapor/Sources/App/Migrations,examples/vapor/Sources/App/Models,examples/vapor/Sources/Run,examples/vapor/Tests/AppTests
 
 # Import Shared settings
 import %workspace%/shared.bazelrc

--- a/examples/vapor/.bazelrc
+++ b/examples/vapor/.bazelrc
@@ -6,3 +6,7 @@ import %workspace%/../../ci.bazelrc
 
 # Try to import a local.rc file; typically, written by CI
 try-import %workspace%/../../local.bazelrc
+
+# The Vapor tests are very sensitive to the Xcode version being used.
+# This tells Bazel to use the Xcode version specified at //:host_xcodes
+build --xcode_version_config=//:host_xcodes

--- a/examples/vapor/BUILD.bazel
+++ b/examples/vapor/BUILD.bazel
@@ -1,0 +1,25 @@
+# Vapor was not happy building under 13.2.1. Fix the version for now.
+
+xcode_version(
+    name = "version13_1_0_13A1030d",
+    aliases = [
+        "13",
+        "13A1030d",
+        "13.1.0.13A1030d",
+        "13.1",
+        "13.1.0",
+    ],
+    default_ios_sdk_version = "15.0",
+    default_macos_sdk_version = "12.0",
+    default_tvos_sdk_version = "15.0",
+    default_watchos_sdk_version = "8.0",
+    version = "13.1.0.13A1030d",
+)
+
+xcode_config(
+    name = "host_xcodes",
+    default = ":version13_1_0_13A1030d",
+    versions = [
+        ":version13_1_0_13A1030d",
+    ],
+)

--- a/examples/vapor/BUILD.bazel
+++ b/examples/vapor/BUILD.bazel
@@ -1,4 +1,6 @@
 # Vapor was not happy building under 13.2.1. Fix the version for now.
+# See Keith's article for more details:
+# https://www.smileykeith.com/2021/03/08/locking-xcode-in-bazel/
 
 xcode_version(
     name = "version13_1_0_13A1030d",

--- a/examples/vapor/WORKSPACE
+++ b/examples/vapor/WORKSPACE
@@ -47,7 +47,7 @@ spm_repositories(
     dependencies = [
         spm_pkg(
             "https://github.com/vapor/vapor.git",
-            exact_version = "4.54.1",
+            exact_version = "4.55.0",
             products = [
                 "Vapor",
                 "XCTVapor",


### PR DESCRIPTION
Closes #125.

- To avoid a segmentation fault when built with 13.2.1, default the vapor integration test to 13.1.
- Upgraded Vapor to 4.55.0.