### PR TITLE
Transitioned `from_version` to `exact_version` for integration tests.

### DIFF
--- a/examples/interesting_deps/README.md
+++ b/examples/interesting_deps/README.md
@@ -21,7 +21,7 @@ we must specify the correct package name in the `spm_pkg` declaration.
             # Need to specify for the package because the URL basename does not
             # match the package name in the Package.swift.
             name = "libwebp",
-            from_version = "1.2.1",
+            exact_version = "1.2.1",
             products = ["libwebp"],
             url = "https://github.com/SDWebImage/libwebp-Xcode.git",
         ),

--- a/examples/public_hdrs/WORKSPACE
+++ b/examples/public_hdrs/WORKSPACE
@@ -1,7 +1,5 @@
 workspace(name = "trustkit_with_dev_dir_example")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
 local_repository(
     name = "cgrindel_rules_spm",
     path = "../..",
@@ -42,14 +40,10 @@ spm_repositories(
     name = "swift_pkgs",
     dependencies = [
         spm_pkg(
-            url = "https://github.com/datatheorem/TrustKit.git",
-            from_version = "2.0.0",
+            exact_version = "2.0.0",
             products = ["TrustKitStatic"],
+            url = "https://github.com/datatheorem/TrustKit.git",
         ),
-    ],
-    platforms = [
-        ".iOS(.v13)",
-        ".macOS(.v10_14)",
     ],
     env = {
         # If you are testing this locally, set this value to a valid Xcode
@@ -57,4 +51,8 @@ spm_repositories(
         # macos-11.
         # "DEVELOPER_DIR": "/Applications/Xcode_12.5.1.app",
     },
+    platforms = [
+        ".iOS(.v13)",
+        ".macOS(.v10_14)",
+    ],
 )

--- a/examples/simple_with_binary/README.md
+++ b/examples/simple_with_binary/README.md
@@ -14,7 +14,7 @@ spm_repositories(
     dependencies = [
         spm_pkg(
             "https://github.com/apple/swift-log.git",
-            from_version = "1.0.0",
+            exact_version = "1.4.2",
             products = ["Logging"],
         ),
     ],
@@ -26,7 +26,7 @@ spm_repositories(
     dependencies = [
         spm_pkg(
             "https://github.com/realm/SwiftLint.git",
-            from_version = "0.0.0",
+            exact_version = "0.46.5",
             products = ["swiftlint"],
         ),
     ],

--- a/examples/simple_with_binary/WORKSPACE
+++ b/examples/simple_with_binary/WORKSPACE
@@ -1,7 +1,5 @@
 workspace(name = "simple_with_binary_example")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
 local_repository(
     name = "cgrindel_rules_spm",
     path = "../..",
@@ -44,7 +42,7 @@ spm_repositories(
     dependencies = [
         spm_pkg(
             "https://github.com/apple/swift-log.git",
-            from_version = "1.0.0",
+            exact_version = "1.4.2",
             products = ["Logging"],
         ),
     ],
@@ -60,12 +58,12 @@ spm_repositories(
     dependencies = [
         spm_pkg(
             "https://github.com/realm/SwiftLint.git",
-            from_version = "0.0.0",
+            exact_version = "0.46.5",
             products = ["swiftlint"],
         ),
         spm_pkg(
             "https://github.com/nicklockwood/SwiftFormat.git",
-            from_version = "0.0.0",
+            exact_version = "0.49.6",
             products = [
                 "swiftformat",
             ],

--- a/examples/simple_with_dev_dir/WORKSPACE
+++ b/examples/simple_with_dev_dir/WORKSPACE
@@ -1,7 +1,5 @@
 workspace(name = "simple_with_dev_dir_example")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
 local_repository(
     name = "cgrindel_rules_spm",
     path = "../..",
@@ -43,7 +41,7 @@ spm_repositories(
     dependencies = [
         spm_pkg(
             "https://github.com/apple/swift-log.git",
-            from_version = "1.0.0",
+            exact_version = "1.4.2",
             products = ["Logging"],
         ),
     ],


### PR DESCRIPTION
This will help avoid pulling in breaking changes from dependencies. However, breaking changes can occur if a dependency itself uses a "from" strategy for its versioning.