### PR TITLE
Upgrade `rules_bazel_integration_test` to use `bazel-contrib` release.

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,3 +1,3 @@
 # Do not add the examples directories here. Execute
-# `bazel run @cgrindel_rules_bazel_integration_test//tools:update_deleted_packages` 
+# `bazel run @contrib_rules_bazel_integration_test//tools:update_deleted_packages` 
 # to update the deleted packages in the .bazelrc.

--- a/.bazelrc
+++ b/.bazelrc
@@ -2,7 +2,7 @@
 # Trick bazel into treating BUILD files under examples/* as being regular files
 # This lets us glob() up all the files inside the examples to make them inputs to tests
 # (Note, we cannot use `common --deleted_packages` because the bazel version command doesn't support it)
-# To update these lines, run `bazel run @cgrindel_rules_bazel_integration_test//tools:update_deleted_packages`.
+# To update these lines, run `bazel run @contrib_rules_bazel_integration_test//tools:update_deleted_packages`.
 build --deleted_packages=examples/interesting_deps,examples/ios_sim/Sources/Foo,examples/ios_sim/Tests/FooTests,examples/local_package,examples/public_hdrs,examples/simple,examples/simple_revision,examples/simple_with_binary,examples/simple_with_dev_dir,examples/vapor,examples/vapor/Sources/App/Configuration,examples/vapor/Sources/App/Migrations,examples/vapor/Sources/App/Models,examples/vapor/Sources/Run,examples/vapor/Tests/AppTests
 query --deleted_packages=examples/interesting_deps,examples/ios_sim/Sources/Foo,examples/ios_sim/Tests/FooTests,examples/local_package,examples/public_hdrs,examples/simple,examples/simple_revision,examples/simple_with_binary,examples/simple_with_dev_dir,examples/vapor,examples/vapor/Sources/App/Configuration,examples/vapor/Sources/App/Migrations,examples/vapor/Sources/App/Models,examples/vapor/Sources/Run,examples/vapor/Tests/AppTests
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -5,7 +5,7 @@ load(
     "updatesrc_update_all",
 )
 load(
-    "@cgrindel_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
+    "@contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
     "integration_test_utils",
 )
 
@@ -18,7 +18,7 @@ bzlformat_missing_pkgs(
 updatesrc_update_all(
     name = "update_all",
     targets_to_run = [
-        "@cgrindel_rules_bazel_integration_test//tools:update_deleted_packages",
+        "@contrib_rules_bazel_integration_test//tools:update_deleted_packages",
         ":bzlformat_missing_pkgs_fix",
     ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -44,11 +44,22 @@ buildifier_prebuilt_register_toolchains()
 
 # MARK: - Integration Testing
 
-load("@cgrindel_rules_bazel_integration_test//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "contrib_rules_bazel_integration_test",
+    sha256 = "ab9bbf776b5874f8a02f639fec2fbb3e3eefa4403cf861ae00d7c7e4d757f9ff",
+    strip_prefix = "rules_bazel_integration_test-0.6.2",
+    urls = [
+        "http://github.com/bazel-contrib/rules_bazel_integration_test/archive/v0.6.2.tar.gz",
+    ],
+)
+
+load("@contrib_rules_bazel_integration_test//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
 
 bazel_integration_test_rules_dependencies()
 
-load("@cgrindel_rules_bazel_integration_test//bazel_integration_test:defs.bzl", "bazel_binaries")
+load("@contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl", "bazel_binaries")
 load("//:bazel_versions.bzl", "SUPPORTED_BAZEL_VERSIONS")
 
 bazel_binaries(versions = SUPPORTED_BAZEL_VERSIONS)

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load(
-    "@cgrindel_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
+    "@contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
     "bazel_integration_test",
     "bazel_integration_tests",
     "default_test_runner",

--- a/spm/deps.bzl
+++ b/spm/deps.bzl
@@ -43,16 +43,6 @@ def spm_rules_dependencies():
         name = "cgrindel_rules_spm_local_config",
     )
 
-    maybe(
-        http_archive,
-        name = "cgrindel_rules_bazel_integration_test",
-        sha256 = "39071d2ec8e3be74c8c4a6c395247182b987cdb78d3a3955b39e343ece624982",
-        strip_prefix = "rules_bazel_integration_test-0.5.0",
-        urls = [
-            "http://github.com/cgrindel/rules_bazel_integration_test/archive/v0.5.0.tar.gz",
-        ],
-    )
-
     # Master as of 2022-04-09
     _RULES_CC_VERSION = "58f8e026c00a8a20767e3dc669f46ba23bc93bdb"
     maybe(


### PR DESCRIPTION
Related to bazel-contrib/rules_bazel_integration_test#47.