### PR TITLE
Always use the package path when resolving checkout location and the target path when resolving source file locations

### DIFF
--- a/doc/repository_files.md
+++ b/doc/repository_files.md
@@ -72,3 +72,23 @@ Finds files with the specified name under the specified path and deletes them.
 | <a id="repository_files.find_and_delete_files-name"></a>name |  A file basename as a <code>string</code>.   |  none |
 
 
+<a id="#repository_files.copy_directory"></a>
+
+## repository_files.copy_directory
+
+<pre>
+repository_files.copy_directory(<a href="#repository_files.copy_directory-repository_ctx">repository_ctx</a>, <a href="#repository_files.copy_directory-src">src</a>, <a href="#repository_files.copy_directory-dest">dest</a>)
+</pre>
+
+Copy a directory.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="repository_files.copy_directory-repository_ctx"></a>repository_ctx |  An instance of <code>repository_ctx</code>.   |  none |
+| <a id="repository_files.copy_directory-src"></a>src |  The path to the direcotry to copy as a <code>string</code>.   |  none |
+| <a id="repository_files.copy_directory-dest"></a>dest |  The path where the directory will be copied as a <code>string</code>.   |  none |
+
+

--- a/spm/private/bazel_build_declarations.bzl
+++ b/spm/private/bazel_build_declarations.bzl
@@ -119,18 +119,18 @@ def _swift_binary(pkg_name, product, target, target_deps):
         targets = [target_decl],
     )
 
-# SourceKitten uses `Source` instead of `Sources`
-_SOURCE_DIR_NAMES = ["Sources", "Source"]
+# # SourceKitten uses `Source` instead of `Sources`
+# _SOURCE_DIR_NAMES = ["Sources", "Source"]
 
-def _find_srcs_dir(repository_ctx, pkg_name):
-    for dir_name in _SOURCE_DIR_NAMES:
-        srcs_dir = paths.join(pkg_name, dir_name)
-        srcs_path = repository_ctx.path(srcs_dir)
-        if srcs_path.exists:
-            return srcs_dir
-    fail("Could not find the sources directory for {pkg_name}".format(
-        pkg_name = pkg_name,
-    ))
+# def _find_srcs_dir(repository_ctx, pkg_name):
+#     for dir_name in _SOURCE_DIR_NAMES:
+#         srcs_dir = paths.join(pkg_name, dir_name)
+#         srcs_path = repository_ctx.path(srcs_dir)
+#         if srcs_path.exists:
+#             return srcs_dir
+#     fail("Could not find the sources directory for {pkg_name}".format(
+#         pkg_name = pkg_name,
+#     ))
 
 def _clang_library(repository_ctx, pkg_name, target, target_deps):
     """Generates a build declaration for clang libraries and system libraries.
@@ -147,10 +147,26 @@ def _clang_library(repository_ctx, pkg_name, target, target_deps):
     """
     target_name = target["name"]
 
-    srcs_dir = _find_srcs_dir(repository_ctx, pkg_name)
+    # DEBUG BEGIN
+    print("*** CHUCK ------------")
+    print("*** CHUCK target: ")
+    for key in target:
+        print("*** CHUCK", key, ":", target[key])
+
+    # DEBUG END
+
+    # srcs_dir = _find_srcs_dir(repository_ctx, pkg_name)
+    # collected_files = clang_files.collect_files(
+    #     repository_ctx,
+    #     paths.join(srcs_dir, target_name),
+    #     remove_prefix = "{}/".format(pkg_name),
+    # )
+
+    target_path = target["path"]
     collected_files = clang_files.collect_files(
         repository_ctx,
-        paths.join(srcs_dir, target_name),
+        # We copy the source files to a directory that is named after the package.
+        paths.join(pkg_name, target_path),
         remove_prefix = "{}/".format(pkg_name),
     )
 

--- a/spm/private/bazel_build_declarations.bzl
+++ b/spm/private/bazel_build_declarations.bzl
@@ -119,19 +119,6 @@ def _swift_binary(pkg_name, product, target, target_deps):
         targets = [target_decl],
     )
 
-# # SourceKitten uses `Source` instead of `Sources`
-# _SOURCE_DIR_NAMES = ["Sources", "Source"]
-
-# def _find_srcs_dir(repository_ctx, pkg_name):
-#     for dir_name in _SOURCE_DIR_NAMES:
-#         srcs_dir = paths.join(pkg_name, dir_name)
-#         srcs_path = repository_ctx.path(srcs_dir)
-#         if srcs_path.exists:
-#             return srcs_dir
-#     fail("Could not find the sources directory for {pkg_name}".format(
-#         pkg_name = pkg_name,
-#     ))
-
 def _clang_library(repository_ctx, pkg_name, target, target_deps):
     """Generates a build declaration for clang libraries and system libraries.
 
@@ -146,21 +133,6 @@ def _clang_library(repository_ctx, pkg_name, target, target_deps):
         A build declaration `struct` as returned by `build_declarations.create`.
     """
     target_name = target["name"]
-
-    # DEBUG BEGIN
-    print("*** CHUCK ------------")
-    print("*** CHUCK target: ")
-    for key in target:
-        print("*** CHUCK", key, ":", target[key])
-
-    # DEBUG END
-
-    # srcs_dir = _find_srcs_dir(repository_ctx, pkg_name)
-    # collected_files = clang_files.collect_files(
-    #     repository_ctx,
-    #     paths.join(srcs_dir, target_name),
-    #     remove_prefix = "{}/".format(pkg_name),
-    # )
 
     target_path = target["path"]
     collected_files = clang_files.collect_files(

--- a/spm/private/repository_files.bzl
+++ b/spm/private/repository_files.bzl
@@ -60,17 +60,23 @@ def _find_and_delete_files(repository_ctx, path, name):
             stderr = exec_result.stderr,
         ))
 
-# TODO: Add doc comment for _copy_directory.
+def _copy_directory(repository_ctx, src, dest):
+    """Copy a directory.
 
-def _copy_directory(repository_ctx, src_path, dest_path):
+    Args:
+        repository_ctx: An instance of `repository_ctx`.
+        src: The path to the direcotry to copy as a `string`.
+        dest: The path where the directory will be copied as a `string`.
+    """
+
     # Copy the sources from the checkout directory
     repository_ctx.execute(
         [
             "cp",
             "-R",
             "-f",
-            src_path,
-            dest_path,
+            src,
+            dest,
         ],
     )
 

--- a/spm/private/repository_files.bzl
+++ b/spm/private/repository_files.bzl
@@ -60,8 +60,23 @@ def _find_and_delete_files(repository_ctx, path, name):
             stderr = exec_result.stderr,
         ))
 
+# TODO: Add doc comment for _copy_directory.
+
+def _copy_directory(repository_ctx, src_path, dest_path):
+    # Copy the sources from the checkout directory
+    repository_ctx.execute(
+        [
+            "cp",
+            "-R",
+            "-f",
+            src_path,
+            dest_path,
+        ],
+    )
+
 repository_files = struct(
     list_files_under = _list_files_under,
     list_directories_under = _list_directories_under,
     find_and_delete_files = _find_and_delete_files,
+    copy_directory = _copy_directory,
 )

--- a/spm/private/spm_repositories.bzl
+++ b/spm/private/spm_repositories.bzl
@@ -200,7 +200,7 @@ def _create_bazel_module_decls(
         if pds.is_clang_target(target):
             build_decl = build_declarations.merge(
                 build_decl,
-                bazel_build_declarations.system_library(
+                bazel_build_declarations.clang_library(
                     repository_ctx,
                     pkg_name,
                     target,
@@ -228,7 +228,7 @@ def _create_bazel_module_decls(
             if pds.is_system_target(target):
                 build_decl = build_declarations.merge(
                     build_decl,
-                    bazel_build_declarations.system_library(
+                    bazel_build_declarations.library_library(
                         repository_ctx,
                         pkg_name,
                         target,
@@ -595,7 +595,9 @@ spm_repositories = repository_rule(
     implementation = _spm_repositories_impl,
     attrs = {
         "build_mode": attr.string(
-            default = "spm",
+            # TODO: FIX ME!
+            # default = "spm",
+            default = "bazel",
             values = ["spm", "bazel"],
             doc = """\
 Specifies how `rules_spm` will build the Swift packages.

--- a/spm/private/spm_repositories.bzl
+++ b/spm/private/spm_repositories.bzl
@@ -73,14 +73,10 @@ def _generate_bazel_pkg(
         )
     elif build_mode == spm_build_modes.BAZEL:
         # Copy the sources from the checkout directory
-        repository_ctx.execute(
-            [
-                "cp",
-                "-R",
-                "-f",
-                paths.join(spm_common.checkouts_path, pkg_name),
-                pkg_name,
-            ],
+        repository_files.copy_directory(
+            repository_ctx,
+            pkg_desc["path"],
+            pkg_name,
         )
         build_decl = _create_bazel_module_decls(
             repository_ctx,
@@ -184,6 +180,14 @@ def _create_bazel_module_decls(
         exec_products):
     build_decl = build_declarations.create()
     pkg_name = pkg_desc["name"]
+
+    # DEBUG BEGIN
+    print("*** CHUCK ===============")
+    print("*** CHUCK pkg_desc: ")
+    for key in pkg_desc:
+        print("*** CHUCK", key, ":", pkg_desc[key])
+
+    # DEBUG END
 
     target_refs = [
         tr

--- a/spm/private/spm_repositories.bzl
+++ b/spm/private/spm_repositories.bzl
@@ -591,9 +591,7 @@ spm_repositories = repository_rule(
     implementation = _spm_repositories_impl,
     attrs = {
         "build_mode": attr.string(
-            # TODO: FIX ME!
-            # default = "spm",
-            default = "bazel",
+            default = "spm",
             values = ["spm", "bazel"],
             doc = """\
 Specifies how `rules_spm` will build the Swift packages.

--- a/spm/private/spm_repositories.bzl
+++ b/spm/private/spm_repositories.bzl
@@ -182,7 +182,7 @@ def _create_bazel_module_decls(
     pkg_name = pkg_desc["name"]
 
     # DEBUG BEGIN
-    print("*** CHUCK ===============")
+    print("*** CHUCK =============")
     print("*** CHUCK pkg_desc: ")
     for key in pkg_desc:
         print("*** CHUCK", key, ":", pkg_desc[key])

--- a/spm/private/spm_repositories.bzl
+++ b/spm/private/spm_repositories.bzl
@@ -181,14 +181,6 @@ def _create_bazel_module_decls(
     build_decl = build_declarations.create()
     pkg_name = pkg_desc["name"]
 
-    # DEBUG BEGIN
-    print("*** CHUCK =============")
-    print("*** CHUCK pkg_desc: ")
-    for key in pkg_desc:
-        print("*** CHUCK", key, ":", pkg_desc[key])
-
-    # DEBUG END
-
     target_refs = [
         tr
         for tr in dep_target_refs_dict


### PR DESCRIPTION
Related to #149.

- Always use the paths from the package description when resolving checkout location and source file locations.
- Fixed code that calls `build_declarations.clang_library`.