### PR TITLE
Use `FilesToRunProvider.executable` to find the Swift worker executable.

### DIFF
--- a/spm/deps.bzl
+++ b/spm/deps.bzl
@@ -16,15 +16,28 @@ def spm_rules_dependencies():
         sha256 = "74d544d96f4a5bb630d465ca8bbcfe231e3594e5aae57e1edbf17a6eb3ca2506",
     )
 
-    _RULES_SWIFT_VERSION = "1.1.1"
+    # TODO: REVERT ME!
+
+    # _RULES_SWIFT_VERSION = "1.1.1"
+    # maybe(
+    #     http_archive,
+    #     name = "build_bazel_rules_swift",
+    #     sha256 = "043897b483781cfd6cbd521569bfee339c8fbb2ad0f0bdcd1b3749523a262cf4",
+    #     urls = [
+    #         "https://github.com/bazelbuild/rules_swift/releases/download/{version}/rules_swift.{version}.tar.gz".format(
+    #             version = _RULES_SWIFT_VERSION,
+    #         ),
+    #     ],
+    # )
+
+    _RULES_SWIFT_COMMIT_SHA = "8aca87eba7dc9164c9835b887ff58d1c8ddbf20e"
     maybe(
         http_archive,
         name = "build_bazel_rules_swift",
-        sha256 = "043897b483781cfd6cbd521569bfee339c8fbb2ad0f0bdcd1b3749523a262cf4",
+        sha256 = "1218a25ca17bafbd0ece72889233ce4689460673dc9f676d31c55062149b4e26",
+        strip_prefix = "rules_swift-{}".format(_RULES_SWIFT_COMMIT_SHA),
         urls = [
-            "https://github.com/bazelbuild/rules_swift/releases/download/{version}/rules_swift.{version}.tar.gz".format(
-                version = _RULES_SWIFT_VERSION,
-            ),
+            "http://github.com/bazelbuild/rules_swift/archive/{}.tar.gz".format(_RULES_SWIFT_COMMIT_SHA),
         ],
     )
 

--- a/spm/deps.bzl
+++ b/spm/deps.bzl
@@ -16,28 +16,15 @@ def spm_rules_dependencies():
         sha256 = "74d544d96f4a5bb630d465ca8bbcfe231e3594e5aae57e1edbf17a6eb3ca2506",
     )
 
-    # TODO: REVERT ME!
-
-    # _RULES_SWIFT_VERSION = "1.1.1"
-    # maybe(
-    #     http_archive,
-    #     name = "build_bazel_rules_swift",
-    #     sha256 = "043897b483781cfd6cbd521569bfee339c8fbb2ad0f0bdcd1b3749523a262cf4",
-    #     urls = [
-    #         "https://github.com/bazelbuild/rules_swift/releases/download/{version}/rules_swift.{version}.tar.gz".format(
-    #             version = _RULES_SWIFT_VERSION,
-    #         ),
-    #     ],
-    # )
-
-    _RULES_SWIFT_COMMIT_SHA = "8aca87eba7dc9164c9835b887ff58d1c8ddbf20e"
+    _RULES_SWIFT_VERSION = "1.1.1"
     maybe(
         http_archive,
         name = "build_bazel_rules_swift",
-        sha256 = "1218a25ca17bafbd0ece72889233ce4689460673dc9f676d31c55062149b4e26",
-        strip_prefix = "rules_swift-{}".format(_RULES_SWIFT_COMMIT_SHA),
+        sha256 = "043897b483781cfd6cbd521569bfee339c8fbb2ad0f0bdcd1b3749523a262cf4",
         urls = [
-            "http://github.com/bazelbuild/rules_swift/archive/{}.tar.gz".format(_RULES_SWIFT_COMMIT_SHA),
+            "https://github.com/bazelbuild/rules_swift/releases/download/{version}/rules_swift.{version}.tar.gz".format(
+                version = _RULES_SWIFT_VERSION,
+            ),
         ],
     )
 

--- a/spm/private/spm_linux_toolchain.bzl
+++ b/spm/private/spm_linux_toolchain.bzl
@@ -22,6 +22,8 @@ Could not parse the version number for Swift package manager. {version}\
 
 def _create_build_tool_config(ctx, target_triple, spm_configuration):
     swift_worker = ctx.executable._swift_worker
+
+    # swift_worker = ctx.attr._swift_worker[DefaultInfo].files_to_run
     swift_exec = ctx.attr.swift_exec
     args = [
         "--worker",
@@ -127,7 +129,7 @@ The path to the Swift executable.\
             default = "//spm/private:exec_spm_build",
         ),
         "_spm_utilities": attr.label(
-            cfg = "host",
+            cfg = "exec",
             allow_files = True,
             default = Label(
                 "@cgrindel_rules_spm_local_config//spm_utilities:all_utilities",
@@ -137,7 +139,7 @@ The location for the utilities that are required by SPM.\
 """,
         ),
         "_swift_worker": attr.label(
-            cfg = "host",
+            cfg = "exec",
             allow_files = True,
             default = Label(
                 "@build_bazel_rules_swift//tools/worker",

--- a/spm/private/spm_linux_toolchain.bzl
+++ b/spm/private/spm_linux_toolchain.bzl
@@ -21,8 +21,9 @@ Could not parse the version number for Swift package manager. {version}\
     return current_version >= desired_version_value
 
 def _create_build_tool_config(ctx, target_triple, spm_configuration):
-    swift_worker = ctx.executable._swift_worker
+    # swift_worker = ctx.executable._swift_worker
 
+    swift_worker = ctx.attr._swift_worker[DefaultInfo].files_to_run
     swift_exec = ctx.attr.swift_exec
     args = [
         "--worker",

--- a/spm/private/spm_linux_toolchain.bzl
+++ b/spm/private/spm_linux_toolchain.bzl
@@ -21,9 +21,8 @@ Could not parse the version number for Swift package manager. {version}\
     return current_version >= desired_version_value
 
 def _create_build_tool_config(ctx, target_triple, spm_configuration):
-    # swift_worker = ctx.executable._swift_worker
+    swift_worker = ctx.attr._swift_worker[DefaultInfo].files_to_run.executable
 
-    swift_worker = ctx.attr._swift_worker[DefaultInfo].files_to_run
     swift_exec = ctx.attr.swift_exec
     args = [
         "--worker",

--- a/spm/private/spm_linux_toolchain.bzl
+++ b/spm/private/spm_linux_toolchain.bzl
@@ -21,12 +21,12 @@ Could not parse the version number for Swift package manager. {version}\
     return current_version >= desired_version_value
 
 def _create_build_tool_config(ctx, target_triple, spm_configuration):
-    swift_worker = ctx.attr._swift_worker[DefaultInfo].files_to_run.executable
+    swift_worker = ctx.attr._swift_worker[DefaultInfo].files_to_run
 
     swift_exec = ctx.attr.swift_exec
     args = [
         "--worker",
-        swift_worker,
+        swift_worker.executable,
         "--swift",
         swift_exec,
     ]
@@ -141,7 +141,7 @@ The location for the utilities that are required by SPM.\
             cfg = "exec",
             allow_files = True,
             default = Label(
-                "@build_bazel_rules_swift//tools/worker",
+                "@build_bazel_rules_swift//tools/worker:worker_wrapper",
             ),
             doc = """\
 An executable that wraps Swift compiler invocations and also provides support \

--- a/spm/private/spm_linux_toolchain.bzl
+++ b/spm/private/spm_linux_toolchain.bzl
@@ -23,7 +23,6 @@ Could not parse the version number for Swift package manager. {version}\
 def _create_build_tool_config(ctx, target_triple, spm_configuration):
     swift_worker = ctx.executable._swift_worker
 
-    # swift_worker = ctx.attr._swift_worker[DefaultInfo].files_to_run
     swift_exec = ctx.attr.swift_exec
     args = [
         "--worker",

--- a/spm/private/spm_xcode_toolchain.bzl
+++ b/spm/private/spm_xcode_toolchain.bzl
@@ -25,11 +25,11 @@ def _create_spm_platform_info(swift_cpu, swift_os):
     )
 
 def _create_build_tool_config(ctx, xcode_config, target_triple, spm_configuration, sdk_name = None):
-    swift_worker = ctx.attr._swift_worker[DefaultInfo].files_to_run.executable
+    swift_worker = ctx.attr._swift_worker[DefaultInfo].files_to_run
 
     args = [
         "--worker",
-        swift_worker,
+        swift_worker.executable,
     ]
     if sdk_name:
         args.extend(["--sdk_name", sdk_name])
@@ -141,7 +141,7 @@ The location for the utilities that are required by SPM.\
             cfg = "exec",
             allow_files = True,
             default = Label(
-                "@build_bazel_rules_swift//tools/worker",
+                "@build_bazel_rules_swift//tools/worker:worker_wrapper",
             ),
             doc = """\
 An executable that wraps Swift compiler invocations and also provides support

--- a/spm/private/spm_xcode_toolchain.bzl
+++ b/spm/private/spm_xcode_toolchain.bzl
@@ -26,7 +26,6 @@ def _create_spm_platform_info(swift_cpu, swift_os):
 
 def _create_build_tool_config(ctx, xcode_config, target_triple, spm_configuration, sdk_name = None):
     swift_worker = ctx.executable._swift_worker
-    # swift_worker = ctx.attr._swift_worker[DefaultInfo].files_to_run
 
     args = [
         "--worker",

--- a/spm/private/spm_xcode_toolchain.bzl
+++ b/spm/private/spm_xcode_toolchain.bzl
@@ -25,7 +25,8 @@ def _create_spm_platform_info(swift_cpu, swift_os):
     )
 
 def _create_build_tool_config(ctx, xcode_config, target_triple, spm_configuration, sdk_name = None):
-    swift_worker = ctx.executable._swift_worker
+    # swift_worker = ctx.executable._swift_worker
+    swift_worker = ctx.attr._swift_worker[DefaultInfo].files_to_run
 
     args = [
         "--worker",

--- a/spm/private/spm_xcode_toolchain.bzl
+++ b/spm/private/spm_xcode_toolchain.bzl
@@ -25,8 +25,7 @@ def _create_spm_platform_info(swift_cpu, swift_os):
     )
 
 def _create_build_tool_config(ctx, xcode_config, target_triple, spm_configuration, sdk_name = None):
-    # swift_worker = ctx.executable._swift_worker
-    swift_worker = ctx.attr._swift_worker[DefaultInfo].files_to_run
+    swift_worker = ctx.attr._swift_worker[DefaultInfo].files_to_run.executable
 
     args = [
         "--worker",

--- a/spm/private/spm_xcode_toolchain.bzl
+++ b/spm/private/spm_xcode_toolchain.bzl
@@ -26,6 +26,7 @@ def _create_spm_platform_info(swift_cpu, swift_os):
 
 def _create_build_tool_config(ctx, xcode_config, target_triple, spm_configuration, sdk_name = None):
     swift_worker = ctx.executable._swift_worker
+    # swift_worker = ctx.attr._swift_worker[DefaultInfo].files_to_run
 
     args = [
         "--worker",
@@ -128,7 +129,7 @@ spm_xcode_toolchain = rule(
             default = "//spm/private:exec_spm_build",
         ),
         "_spm_utilities": attr.label(
-            cfg = "host",
+            cfg = "exec",
             allow_files = True,
             default = Label(
                 "@cgrindel_rules_spm_local_config//spm_utilities:all_utilities",
@@ -138,7 +139,7 @@ The location for the utilities that are required by SPM.\
 """,
         ),
         "_swift_worker": attr.label(
-            cfg = "host",
+            cfg = "exec",
             allow_files = True,
             default = Label(
                 "@build_bazel_rules_swift//tools/worker",


### PR DESCRIPTION
Closes #164.