### PR TITLE
Add support for setting defines of declared swift_library

### DIFF
--- a/spm/private/bazel_build_declarations.bzl
+++ b/spm/private/bazel_build_declarations.bzl
@@ -20,6 +20,9 @@ swift_library(
     deps = [
 {deps}
     ],
+    defines = [
+{defines}
+    ],
     visibility = ["//visibility:public"],
 )
 """
@@ -74,6 +77,9 @@ def _swift_library(pkg_name, target, target_deps):
         _SWIFT_BZL_LOCATION,
         _SWIFT_LIBRARY_TYPE,
     )
+
+    defines_str = build_declarations.bazel_defines_str(target["manifest"])
+        
     target_decl = build_declarations.target(
         type = _SWIFT_LIBRARY_TYPE,
         name = target_name,
@@ -82,6 +88,7 @@ def _swift_library(pkg_name, target, target_deps):
             module_name = target_name,
             srcs = srcs_str,
             deps = deps_str,
+            defines = defines_str,
         ),
     )
     return build_declarations.create(

--- a/spm/private/build_declarations.bzl
+++ b/spm/private/build_declarations.bzl
@@ -233,6 +233,22 @@ def _bazel_deps_str(pkg_name, target_deps):
         target_labels.append(_target_ref_str(pkg_name, target_ref))
     return _bazel_list_str(target_labels, double_quote_values = True)
 
+def _bazel_defines_str(target_manifest):
+    """Create defines list string suitable for injection into a module template.
+
+    Args:
+        target_manifest: the manifest of a target as output by SPM.
+
+    Returns:
+        A `string` value.
+    """
+    defines = []
+    for s in target_manifest["settings"]:
+        kind = s["kind"]
+        if "define" in kind:
+            defines.extend(kind["define"].values())
+    return _bazel_list_str(defines, double_quote_values = True)
+
 def _quote_str(value):
     return "\"{}\"".format(value)
 
@@ -275,5 +291,6 @@ build_declarations = struct(
     write_build_file = _write_build_file,
     bazel_list_str = _bazel_list_str,
     bazel_deps_str = _bazel_deps_str,
+    bazel_defines_str = _bazel_defines_str,
     quote_str = _quote_str,
 )

--- a/spm/private/root.BUILD.bazel.tpl
+++ b/spm/private/root.BUILD.bazel.tpl
@@ -11,7 +11,7 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "all_srcs",
-    srcs = glob(["**"]),
+    srcs = glob(["**/*.swift"]),
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
While trying to use [Auth0.swift](https://github.com/auth0/Auth0.swift.git) I realized it failed to compile because `WEB_AUTH_PLATFORM` wasn't defined.

This patch adds support to adding the output of `manifest.settings.kind["define"]` to the `defines` of the generated `swift_library` (I use `spm_repositories` in `bazel` mode).

I haven't added support to the `spm_swift_library` counterpart, and I could give it a try if you'd like me to.