### PR TITLE
Move main to AsyncMain for `spm_parser`

### DIFF
--- a/tools/spm_parser/Sources/spm_parser/AsyncMain.swift
+++ b/tools/spm_parser/Sources/spm_parser/AsyncMain.swift
@@ -1,0 +1,8 @@
+import ArgumentParser
+
+@main
+enum AsyncMain {
+    static func main() async {
+        await Dump.main()
+    }
+}

--- a/tools/spm_parser/Sources/spm_parser/Dump.swift
+++ b/tools/spm_parser/Sources/spm_parser/Dump.swift
@@ -4,7 +4,6 @@ import Foundation
 import TSCBasic
 import Workspace
 
-@main
 struct Dump: AsyncParsableCommand {
     enum DumpError: Error {
         case failedToCreateOutputFile(String)


### PR DESCRIPTION
Closes #172.

- Move main for the application to work around compilation issues with select Xcode versions.