### PR TITLE
fix: ensure `swift-argument-parser` stays at 1.0.3

### DIFF
--- a/tools/spm_parser/Package.swift
+++ b/tools/spm_parser/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     ],
     dependencies: [
         // Need to match the version that is used in swift-package-manager
-        .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "1.0.3")),
+        .package(url: "https://github.com/apple/swift-argument-parser", exact: "1.0.3"),
         .package(
             url: "https://github.com/apple/swift-package-manager",
             revision: "54d12394b7ff04e63d11a4d2eb6294d3ed1816ed"


### PR DESCRIPTION
Swift package manager requires a specific version number for swift-argument-parser.