### PR TITLE
fix: set the default Xcode version to 14.0.1 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,15 @@ jobs:
     env:
       USE_BAZEL_VERSION: cgrindel/6.0.0-keith_patch
     steps:
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '14.0.1'
+    - name: Confirm Xcode Version
+      shell: bash
+      run: |
+        # Print used xCode version
+        xcode-select -print-path
+        xcodebuild -version
     - uses: actions/checkout@v3
     - uses: cgrindel/gha_set_up_bazel@v1
       with:


### PR DESCRIPTION
Last night, multiple projects that build on macOS runners started failing. It looks like GitHub rolled out [a new image](https://github.com/actions/runner-images/blob/macOS-12/20230117.3/images/macos/macos-12-Readme.md) that is causing problems. For now, try using the previous default version of Xcode, 14.0.1.